### PR TITLE
Add recurring event modifications and copy functionality

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -436,4 +436,58 @@
     padding: 4px 8px;
     border-radius: 3px;
     border: 1px solid #c5d9ed;
+}
+
+/* Recurring Indicator Styles */
+.recurring-indicator {
+    color: #0073aa;
+    font-size: 11px;
+    font-weight: 500;
+    display: block;
+    margin-top: 2px;
+}
+
+/* Copy button styling */
+.row-actions .copy {
+    color: #0073aa;
+}
+
+.row-actions .copy:hover {
+    color: #005177;
+}
+
+/* Skipped Occurrences Management Styles */
+.mayo-skipped-occurrences-list {
+    margin-bottom: 16px;
+}
+
+.mayo-skipped-occurrence-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    margin: 4px 0;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.mayo-skipped-occurrence-item span {
+    flex: 1;
+    margin-right: 8px;
+}
+
+.mayo-add-skip-form {
+    margin-top: 12px;
+}
+
+.mayo-add-skip-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.mayo-add-skip-actions .components-button {
+    flex: 1;
 } 

--- a/readme.txt
+++ b/readme.txt
@@ -135,8 +135,17 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.4.0 =
+* Added recurring event modifications functionality allowing admins to skip specific occurrences of recurring events. [#130]
+* Created reusable LocationAddress component for consistent URL detection across EventCard and EventDetails components.
+* Added copy functionality to admin event list for easy event duplication.
+* Improved admin interface with inline recurring indicators in date/time column.
+* Enhanced recurring event management with sidebar controls for skipped occurrences.
+* Updated recurring event generation to filter out skipped dates in API responses.
+
 = 1.3.9 =
 * Fixed location address handling to detect and link directly to URLs instead of Google Maps when URLs are embedded in location addresses. [#129]
+* Added recurring event modifications allowing admins to skip specific occurrences and copy events from the admin list. [#130]
 * Created reusable LocationAddress component for consistent URL detection across EventCard and EventDetails components.
 * Improved user experience for virtual meetings and hybrid events by linking directly to meeting URLs (e.g., Zoom links) instead of redirecting to Google Maps.
 


### PR DESCRIPTION
This PR implements GitHub issue #130 by adding recurring event modifications functionality and copy functionality to the admin interface.

## Changes Made

### Recurring Event Modifications
- Added ability for admins to skip specific occurrences of recurring events
- Created UI in Event Block Editor Sidebar for managing skipped occurrences
- Added skipped_occurrences meta field to store skipped dates
- Updated recurring event generation to filter out skipped dates

### Copy Functionality
- Added copy button to admin event list for easy event duplication
- Copies all event data including meta fields, featured image, categories, and tags
- Copied events are created as drafts for review

### UI Improvements
- Integrated recurring indicators into date/time column
- Removed separate recurring column to save admin list space
- Shows recurring status inline with date/time

## Technical Implementation

- EventBlockEditorSidebar.js: Added skipped occurrences management panel
- Admin.php: Added copy functionality and updated column display
- Rest.php: Updated generate_recurring_events to filter skipped dates
- CSS: Added styling for new UI elements

Closes #130