### PR TITLE
Fix service body display issue in unexpanded event view (#132)

### DIFF
--- a/assets/js/src/components/public/cards/EventCard.js
+++ b/assets/js/src/components/public/cards/EventCard.js
@@ -110,6 +110,11 @@ const EventCard = ({ event, timeFormat, forceExpanded }) => {
                                 Source: {event.external_source.url}
                             </span>
                         )}
+                        {event.meta.service_body && (
+                            <span className="mayo-event-service-body mayo-event-service-body-small">
+                                {getServiceBodyName(event.meta.service_body, sourceId)}
+                            </span>
+                        )}
                         {(event.categories.length > 0 || event.tags.length > 0) && (
                             <div className="mayo-event-brief-taxonomies">
                                 {event.categories.map(cat => (
@@ -122,9 +127,6 @@ const EventCard = ({ event, timeFormat, forceExpanded }) => {
                                         {tag.name}
                                     </span>
                                 ))}
-                                <span key={event.meta.service_body} className="mayo-event-service-body mayo-event-service-body-small">
-                                    {getServiceBodyName(event.meta.service_body, sourceId)}
-                                </span>
                             </div>
                         )}
                     </div>

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.3.8
+ * Version: 1.3.9
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.3.8');
+define('MAYO_VERSION', '1.3.9');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 1.3.8
+Stable tag: 1.3.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -134,6 +134,9 @@ This project is licensed under the GPL v2 or later.
    - Manage submitted events from the WordPress admin dashboard, where you can approve, edit, or delete events.
 
 == Changelog ==
+
+= 1.3.9 =
+* Fixed service body information not displaying in unexpanded view of event listings when events have no categories or tags. [#132]
 
 = 1.3.8 =
 * Fixed location address handling to detect and link directly to URLs instead of Google Maps when URLs are embedded in location addresses. [#129]


### PR DESCRIPTION
## Description

This PR fixes issue #132 where service body information was not displaying in the unexpanded view of event listings when events have no categories or tags.

## Problem

The service body information was only shown in the unexpanded view when . This meant that events without categories or tags would not display their service body information in the brief view, even though the information was available and displayed correctly in the expanded view.

## Solution

- Moved service body display outside of the conditional logic in 
- Service body information now displays independently of categories/tags
- Service body information is always shown when it exists, regardless of whether the event has categories or tags

## Changes Made

- **EventCard.js**: Service body now displays independently in unexpanded view
- **Version bump**: Updated to 1.3.9
- **Changelog**: Added entry for this fix

## Testing

- Service body information should now be visible in unexpanded view for all events that have service body data
- Events with categories/tags should continue to display service body information as before
- Events without categories/tags should now display service body information (previously they did not)

## Related Issue

Closes #132