### PR TITLE
Add International Timezone Support

### DIFF
--- a/assets/js/src/components/admin/EventBlockEditorSidebar.js
+++ b/assets/js/src/components/admin/EventBlockEditorSidebar.js
@@ -12,6 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEventProvider } from '../providers/EventProvider';
 import { useState } from '@wordpress/element';
+import { getTimezoneOptions, getUserTimezone } from '../../timezones';
 
 const EventBlockEditorSidebar = () => {
     const { serviceBodies } = useEventProvider();
@@ -183,15 +184,8 @@ const EventBlockEditorSidebar = () => {
                     </div>
                     <SelectControl
                         label="Timezone"
-                        value={meta.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone}
-                        options={[
-                            { label: 'Eastern Time', value: 'America/New_York' },
-                            { label: 'Central Time', value: 'America/Chicago' },
-                            { label: 'Mountain Time', value: 'America/Denver' },
-                            { label: 'Pacific Time', value: 'America/Los_Angeles' },
-                            { label: 'Alaska Time', value: 'America/Anchorage' },
-                            { label: 'Hawaii Time', value: 'Pacific/Honolulu' }
-                        ]}
+                        value={meta.timezone || getUserTimezone()}
+                        options={getTimezoneOptions()}
                         onChange={value => updateMetaValue('timezone', value)}
                         __nextHasNoMarginBottom={true}
                     />

--- a/assets/js/src/components/public/EventForm.js
+++ b/assets/js/src/components/public/EventForm.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
+import { getTimezonesByRegion, getUserTimezone } from '../../timezones';
 
 const EventForm = () => {
     // Get the settings from the data attribute
@@ -65,7 +66,7 @@ const EventForm = () => {
         event_end_date: '',
         event_start_time: '',
         event_end_time: '',
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        timezone: getUserTimezone(),
         description: '',
         flyer: null,
         location_name: '',
@@ -545,12 +546,15 @@ const EventForm = () => {
                         onChange={handleChange}
                         required={isFieldRequired('timezone')}
                     >
-                        <option value="America/New_York">Eastern Time</option>
-                        <option value="America/Chicago">Central Time</option>
-                        <option value="America/Denver">Mountain Time</option>
-                        <option value="America/Los_Angeles">Pacific Time</option>
-                        <option value="America/Anchorage">Alaska Time</option>
-                        <option value="Pacific/Honolulu">Hawaii Time</option>
+                        {Object.entries(getTimezonesByRegion()).map(([region, timezones]) => (
+                            <optgroup key={region} label={region}>
+                                {timezones.map(tz => (
+                                    <option key={tz.value} value={tz.value}>
+                                        {tz.label}
+                                    </option>
+                                ))}
+                            </optgroup>
+                        ))}
                     </select>
                 </div>
 

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -3,6 +3,7 @@ import EventCard from './cards/EventCard';
 import EventWidgetCard from './cards/EventWidgetCard';
 import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
+import { getUserTimezone } from '../../timezones';
 
 const EventList = ({ widget = false, settings = {} }) => {
     const containerRef = useRef(null);
@@ -25,7 +26,7 @@ const EventList = ({ widget = false, settings = {} }) => {
     const { updateExternalServiceBodies } = useEventProvider();
     
     // Get user's current timezone
-    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timezone || 'America/New_York';
+    const userTimezone = getUserTimezone();
 
     // Initialize component
     useEffect(() => {

--- a/assets/js/src/timezones.js
+++ b/assets/js/src/timezones.js
@@ -1,0 +1,127 @@
+/**
+ * Comprehensive timezone list including international zones
+ * Organized by region for better user experience
+ */
+
+export const timezones = [
+    // North America
+    { label: 'Eastern Time (US/Canada)', value: 'America/New_York', region: 'North America' },
+    { label: 'Central Time (US/Canada)', value: 'America/Chicago', region: 'North America' },
+    { label: 'Mountain Time (US/Canada)', value: 'America/Denver', region: 'North America' },
+    { label: 'Pacific Time (US/Canada)', value: 'America/Los_Angeles', region: 'North America' },
+    { label: 'Alaska Time (US)', value: 'America/Anchorage', region: 'North America' },
+    { label: 'Hawaii Time (US)', value: 'Pacific/Honolulu', region: 'North America' },
+    { label: 'Atlantic Time (Canada)', value: 'America/Halifax', region: 'North America' },
+    { label: 'Newfoundland Time (Canada)', value: 'America/St_Johns', region: 'North America' },
+    { label: 'Mexico City Time', value: 'America/Mexico_City', region: 'North America' },
+
+    // Europe
+    { label: 'London (GMT/BST)', value: 'Europe/London', region: 'Europe' },
+    { label: 'Paris (CET/CEST)', value: 'Europe/Paris', region: 'Europe' },
+    { label: 'Berlin (CET/CEST)', value: 'Europe/Berlin', region: 'Europe' },
+    { label: 'Rome (CET/CEST)', value: 'Europe/Rome', region: 'Europe' },
+    { label: 'Madrid (CET/CEST)', value: 'Europe/Madrid', region: 'Europe' },
+    { label: 'Amsterdam (CET/CEST)', value: 'Europe/Amsterdam', region: 'Europe' },
+    { label: 'Brussels (CET/CEST)', value: 'Europe/Brussels', region: 'Europe' },
+    { label: 'Zurich (CET/CEST)', value: 'Europe/Zurich', region: 'Europe' },
+    { label: 'Vienna (CET/CEST)', value: 'Europe/Vienna', region: 'Europe' },
+    { label: 'Stockholm (CET/CEST)', value: 'Europe/Stockholm', region: 'Europe' },
+    { label: 'Oslo (CET/CEST)', value: 'Europe/Oslo', region: 'Europe' },
+    { label: 'Copenhagen (CET/CEST)', value: 'Europe/Copenhagen', region: 'Europe' },
+    { label: 'Helsinki (EET/EEST)', value: 'Europe/Helsinki', region: 'Europe' },
+    { label: 'Athens (EET/EEST)', value: 'Europe/Athens', region: 'Europe' },
+    { label: 'Istanbul (TRT)', value: 'Europe/Istanbul', region: 'Europe' },
+    { label: 'Moscow (MSK)', value: 'Europe/Moscow', region: 'Europe' },
+    { label: 'Dublin (GMT/IST)', value: 'Europe/Dublin', region: 'Europe' },
+    { label: 'Lisbon (WET/WEST)', value: 'Europe/Lisbon', region: 'Europe' },
+
+    // Asia
+    { label: 'Tokyo (JST)', value: 'Asia/Tokyo', region: 'Asia' },
+    { label: 'Shanghai (CST)', value: 'Asia/Shanghai', region: 'Asia' },
+    { label: 'Hong Kong (HKT)', value: 'Asia/Hong_Kong', region: 'Asia' },
+    { label: 'Singapore (SGT)', value: 'Asia/Singapore', region: 'Asia' },
+    { label: 'Seoul (KST)', value: 'Asia/Seoul', region: 'Asia' },
+    { label: 'Bangkok (ICT)', value: 'Asia/Bangkok', region: 'Asia' },
+    { label: 'Manila (PHT)', value: 'Asia/Manila', region: 'Asia' },
+    { label: 'Jakarta (WIB)', value: 'Asia/Jakarta', region: 'Asia' },
+    { label: 'Mumbai (IST)', value: 'Asia/Kolkata', region: 'Asia' },
+    { label: 'Dubai (GST)', value: 'Asia/Dubai', region: 'Asia' },
+    { label: 'Riyadh (AST)', value: 'Asia/Riyadh', region: 'Asia' },
+    { label: 'Tel Aviv (IST)', value: 'Asia/Jerusalem', region: 'Asia' },
+    { label: 'Dhaka (BST)', value: 'Asia/Dhaka', region: 'Asia' },
+    { label: 'Karachi (PKT)', value: 'Asia/Karachi', region: 'Asia' },
+    { label: 'Tashkent (UZT)', value: 'Asia/Tashkent', region: 'Asia' },
+
+    // Australia & Oceania
+    { label: 'Sydney (AEST/AEDT)', value: 'Australia/Sydney', region: 'Australia & Oceania' },
+    { label: 'Melbourne (AEST/AEDT)', value: 'Australia/Melbourne', region: 'Australia & Oceania' },
+    { label: 'Brisbane (AEST)', value: 'Australia/Brisbane', region: 'Australia & Oceania' },
+    { label: 'Perth (AWST)', value: 'Australia/Perth', region: 'Australia & Oceania' },
+    { label: 'Adelaide (ACST/ACDT)', value: 'Australia/Adelaide', region: 'Australia & Oceania' },
+    { label: 'Darwin (ACST)', value: 'Australia/Darwin', region: 'Australia & Oceania' },
+    { label: 'Hobart (AEST/AEDT)', value: 'Australia/Hobart', region: 'Australia & Oceania' },
+    { label: 'Auckland (NZST/NZDT)', value: 'Pacific/Auckland', region: 'Australia & Oceania' },
+    { label: 'Wellington (NZST/NZDT)', value: 'Pacific/Auckland', region: 'Australia & Oceania' },
+    { label: 'Fiji (FJT)', value: 'Pacific/Fiji', region: 'Australia & Oceania' },
+
+    // Africa
+    { label: 'Cairo (EET)', value: 'Africa/Cairo', region: 'Africa' },
+    { label: 'Cape Town (SAST)', value: 'Africa/Johannesburg', region: 'Africa' },
+    { label: 'Lagos (WAT)', value: 'Africa/Lagos', region: 'Africa' },
+    { label: 'Nairobi (EAT)', value: 'Africa/Nairobi', region: 'Africa' },
+    { label: 'Casablanca (WET)', value: 'Africa/Casablanca', region: 'Africa' },
+    { label: 'Tunis (CET)', value: 'Africa/Tunis', region: 'Africa' },
+
+    // South America
+    { label: 'São Paulo (BRT)', value: 'America/Sao_Paulo', region: 'South America' },
+    { label: 'Buenos Aires (ART)', value: 'America/Argentina/Buenos_Aires', region: 'South America' },
+    { label: 'Santiago (CLT)', value: 'America/Santiago', region: 'South America' },
+    { label: 'Lima (PET)', value: 'America/Lima', region: 'South America' },
+    { label: 'Bogotá (COT)', value: 'America/Bogota', region: 'South America' },
+    { label: 'Caracas (VET)', value: 'America/Caracas', region: 'South America' }
+];
+
+/**
+ * Get timezone options grouped by region for select elements
+ */
+export const getTimezonesByRegion = () => {
+    const grouped = {};
+    timezones.forEach(tz => {
+        if (!grouped[tz.region]) {
+            grouped[tz.region] = [];
+        }
+        grouped[tz.region].push(tz);
+    });
+    return grouped;
+};
+
+/**
+ * Get flat list of timezone options for simple selects
+ */
+export const getTimezoneOptions = () => {
+    return timezones.map(tz => ({
+        label: tz.label,
+        value: tz.value
+    }));
+};
+
+/**
+ * Find timezone by value
+ */
+export const getTimezoneByValue = (value) => {
+    return timezones.find(tz => tz.value === value);
+};
+
+/**
+ * Get user's detected timezone from browser
+ */
+export const getUserTimezone = () => {
+    try {
+        const userTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        // Check if the detected timezone is in our list
+        const found = timezones.find(tz => tz.value === userTz);
+        return found ? userTz : 'America/New_York'; // Fallback to Eastern Time
+    } catch (e) {
+        return 'America/New_York'; // Fallback
+    }
+};

--- a/includes/Rest.php
+++ b/includes/Rest.php
@@ -412,7 +412,7 @@ class Rest {
         $relation = isset($params['relation']) ? sanitize_text_field(wp_unslash($params['relation'])) : 'AND';
         $categories = isset($params['categories']) ? sanitize_text_field(wp_unslash($params['categories'])) : '';
         $tags = isset($params['tags']) ? sanitize_text_field(wp_unslash($params['tags'])) : '';
-        $timezone = isset($params['timezone']) ? urldecode(sanitize_text_field(wp_unslash($params['timezone']))) : 'America/New_York';
+        $timezone = isset($params['timezone']) ? urldecode(sanitize_text_field(wp_unslash($params['timezone']))) : wp_timezone_string();
 
         $today = new DateTime('now', new \DateTimeZone($timezone));
         $today->setTime(0, 0, 0); // Start of today
@@ -1095,7 +1095,7 @@ class Rest {
                 'event_end_date' => '',
                 'event_start_time' => '',
                 'event_end_time' => '',
-                'timezone' => 'America/New_York',
+                'timezone' => wp_timezone_string(),
                 'event_type' => '',
                 'service_body' => '',
                 'location_name' => '',

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This project is licensed under the GPL v2 or later.
 
 = 1.4.3 =
 * Fixed monthly recurring events bug where "last day of month" events would show repeatedly on the same day instead of advancing to next month. [#143]
+* Added comprehensive international timezone support with 60+ global timezones organized by region (North America, Europe, Asia, Australia/Oceania, Africa, South America). [#142]
+* Improved timezone detection to use browser's actual timezone instead of defaulting to Eastern Time.
+* Enhanced timezone display in both event submission forms and admin interface with grouped regional options.
 
 = 1.4.2 =
 * Fixing missing start year.


### PR DESCRIPTION
## Summary
Adds comprehensive international timezone support with 60+ global timezones organized by region to address the needs of non-US fellowships, particularly for Western Australia users.

## Changes Made
- **New Timezone Library**: Created `timezones.js` with 60+ international timezones grouped by region:
  - North America (US/Canada timezones)
  - Europe (London, Paris, Berlin, Rome, Madrid, etc.)
  - Asia (Tokyo, Shanghai, Hong Kong, Singapore, Mumbai, etc.)
  - **Australia & Oceania** (Sydney, Melbourne, Brisbane, **Perth (AWST)**, Adelaide, etc.)
  - Africa (Cairo, Cape Town, Lagos, Nairobi, etc.)
  - South America (São Paulo, Buenos Aires, Santiago, etc.)

- **Enhanced User Experience**:
  - Automatic timezone detection from browser instead of defaulting to Eastern Time
  - Regional grouping in dropdown menus using optgroups for better navigation
  - Consistent timezone interface across both frontend forms and admin editor

- **Technical Improvements**:
  - Updated `EventForm.js` for public event submissions with international timezone options
  - Updated `EventBlockEditorSidebar.js` for admin Gutenberg editor with full timezone list
  - Enhanced `EventList.js` timezone detection using new utility functions
  - Updated PHP backend (`Rest.php`) to use WordPress timezone settings as fallback
  - Maintained full backward compatibility for existing events

## Features
✅ **60+ International Timezones** with proper IANA timezone identifiers  
✅ **Regional Organization** for easy navigation  
✅ **Perth, Western Australia Support** (AWST timezone) as specifically requested  
✅ **Automatic Browser Detection** for user's current timezone  
✅ **Backward Compatibility** - existing events continue working  
✅ **Consistent Interface** across all forms and admin areas  

## Test Plan
- [x] Frontend event submission form shows all timezones grouped by region
- [x] Admin Gutenberg editor shows full timezone list
- [x] Browser timezone detection works correctly
- [x] Perth, Western Australia timezone available and functional
- [x] Existing events with old timezone values still work
- [x] Timezone display in event lists works with international zones

## Issue Reference
Closes #142

This addresses the original request for international timezone support, specifically enabling Western Australia and other non-US regions to use the Mayo Events Manager effectively.

🤖 Generated with [Claude Code](https://claude.ai/code)