### PR TITLE
Add sortable columns to admin backend

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.4.4');
+define('MAYO_VERSION', '1.4.5');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.4.0",
+  "version": "1.4.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 1.4.4
+Stable tag: 1.4.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -134,6 +134,9 @@ This project is licensed under the GPL v2 or later.
    - Manage submitted events from the WordPress admin dashboard, where you can approve, edit, or delete events.
 
 == Changelog ==
+
+= 1.4.5 =
+* Added sortable columns (Event Type, Date & Time, Service Body, Status) in WordPress admin backend for easier event management. [#153]
 
 = 1.4.4 =
 * Added RSS feed functionality for Mayo events that automatically activates on pages with Mayo event shortcodes or archives.


### PR DESCRIPTION
## Summary
* Added sortable functionality for Event Type, Date & Time, Service Body, and Status columns in WordPress admin backend
* Users can now click column headers to sort events for easier management

## Test plan
- [ ] Navigate to WordPress admin → Mayo → Events list
- [ ] Verify that Event Type, Date & Time, Service Body, and Status column headers are clickable
- [ ] Test sorting in both ascending and descending order for each sortable column
- [ ] Confirm sorting works correctly with various data types (text, dates, status values)

🤖 Generated with [Claude Code](https://claude.ai/code)