### PR TITLE
Add event filtering dropdown to admin backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ This project is licensed under the GPL v2 or later.
 * Fix for events that have timezone set.  No longer selects default timezone in admin interface or shows a timezone. [#161]
 * Added 'order' parameter to [mayo_event_list] shortcode allowing events to be sorted in ascending (ASC, earliest first) or descending (DESC, latest first) order.
 * Fixed archive mode (archive=true) to show ONLY past events that have ended, excluding current and future events.
+* Added event filtering dropdown in admin backend to filter events by Upcoming, Past, or Recurring status for easier event management.
 
 = 1.4.5 =
 * Added sortable columns (Event Type, Date & Time, Service Body, Status) in WordPress admin backend for easier event management. [#153]


### PR DESCRIPTION
This update adds a new filtering dropdown to the WordPress admin event list page, allowing administrators to filter events by:
- Upcoming events (non-recurring events that haven't ended yet)
- Past events (non-recurring events that have already ended)
- Recurring events (all events with daily, weekly, or monthly patterns)

The filter uses WordPress's restrict_manage_posts and pre_get_posts hooks to modify the query based on event dates and recurring patterns. Recurring events are kept separate from past/upcoming filters for easier management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)