### PR TITLE
Move Mayo menu higher in admin sidebar

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -66,7 +66,8 @@ class Admin {
             'manage_options',
             'mayo-events',
             [__CLASS__, 'render_admin_page'],
-            'dashicons-calendar'
+            'dashicons-calendar',
+            58 // Position above Appearance (60)
         );
 
         add_submenu_page(

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.6.1
+ * Version: 1.6.2
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.6.1');
+define('MAYO_VERSION', '1.6.2');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.9
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -186,6 +186,9 @@ This project is licensed under the GPL v2 or later.
    - Manage submitted events from the WordPress admin dashboard, where you can approve, edit, or delete events.
 
 == Changelog ==
+
+= 1.6.2 =
+* Moved Mayo menu higher in admin sidebar (above Appearance) for easier access.
 
 = 1.6.1 =
 * Added API documentation page in the admin menu (Mayo > API) with comprehensive REST API reference.


### PR DESCRIPTION
## Summary
- Positioned Mayo menu above Appearance (position 58) for easier access in the admin sidebar
- Bumped version to 1.6.2

## Test plan
- [x] Verify Mayo menu appears above Appearance in the admin sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)