### PR TITLE
Fix archive list not showing past recurring events

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.6.2');
+define('MAYO_VERSION', '1.6.3');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.6.2 =
+* Fixed archive list not showing past occurrences of recurring events. [#168]
 * Moved Mayo menu higher in admin sidebar (above Appearance) for easier access.
 
 = 1.6.1 =


### PR DESCRIPTION
## Summary
- Fixed archive list not showing past occurrences of recurring events
- Previously, when archive mode was enabled, the recurring event expansion logic was skipped entirely
- Now recurring events are always expanded and filtered based on whether the occurrence's end date is in the past (for archive) or future (for normal view)

Fixes #168

## Test plan
- [x] Create a recurring event with some occurrences in the past
- [x] View the archive list (`archive=true`)
- [ ] Verify past occurrences of the recurring event now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)