### PR TITLE
Fix second event submission failing with single service body

### DIFF
--- a/assets/js/src/components/public/EventForm.js
+++ b/assets/js/src/components/public/EventForm.js
@@ -291,7 +291,10 @@ const EventForm = () => {
                     text: 'Event submitted successfully!' 
                 });
 
-                // Reset form
+                // Reset form - preserve service_body if only one is configured
+                const defaultIds = serviceBodySettings.default_service_bodies?.split(',').map(id => id.trim()).filter(id => id);
+                const preservedServiceBody = (defaultIds && defaultIds.length === 1) ? defaultIds[0] : '';
+
                 setFormData({
                     event_name: '',
                     event_type: '',
@@ -307,7 +310,7 @@ const EventForm = () => {
                     location_details: '',
                     categories: [],
                     tags: [],
-                    service_body: '',
+                    service_body: preservedServiceBody,
                     email: '',
                     contact_name: '',
                     recurring_pattern: {

--- a/readme.txt
+++ b/readme.txt
@@ -189,6 +189,7 @@ This project is licensed under the GPL v2 or later.
 
 = 1.6.2 =
 * Fixed archive list not showing past occurrences of recurring events. [#168]
+* Fixed second event submission failing when single service body is configured. [#177]
 * Moved Mayo menu higher in admin sidebar (above Appearance) for easier access.
 
 = 1.6.1 =


### PR DESCRIPTION
## Summary
- Fixed second event submission failing when a single service body is configured
- When only one service body is configured, the field is hidden and auto-selected
- After successful submission, the form reset was clearing the service_body value, causing subsequent submissions to fail
- Now the form reset preserves the service_body value when only one service body is configured

Fixes #177

## Test plan
- [x] Configure the submission form with a single service body via `[mayo_event_form default_service_bodies="1"]`
- [x] Submit an event
- [x] Without refreshing, submit a second event
- [x] Verify the second submission succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)