### PR TITLE
fix: attach external_source object to external feed events

### DIFF
--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1098,9 +1098,10 @@ class EventsController {
                 'service_bodies' => $service_bodies
             ];
 
-            // Events only reference source by ID (no duplication of service bodies)
+            // Attach full external_source object to each event for frontend use
             foreach ($events as &$event) {
                 $event['source_id'] = $source['id'];
+                $event['external_source'] = $source_info;
             }
 
             return [

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.8.4
+ * Version: 1.8.5
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.8.4');
+define('MAYO_VERSION', '1.8.5');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.9
-Stable tag: 1.8.4
+Stable tag: 1.8.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -186,6 +186,9 @@ This project is licensed under the GPL v2 or later.
    - Manage submitted events from the WordPress admin dashboard, where you can approve, edit, or delete events.
 
 == Changelog ==
+
+= 1.8.5 =
+* Fixed external feed events not displaying service body names correctly. [#234]
 
 = 1.8.4 =
 * Added custom URL/link support for announcements with selectable icons. [#227]


### PR DESCRIPTION
## Summary
- Fixed external feed events not displaying service body names correctly
- Each external event now includes the full `external_source` object with service bodies from the external source's BMLT server
- This allows the frontend JavaScript and RSS feed to properly resolve service body names

Fixes #234

## Test plan
- [x] Call `/wp-json/event-manager/v1/events?source_ids=<external_source_id>` and verify events include `external_source` object
- [x] View an event list with external source events and verify service body names display correctly
- [ ] Verify RSS feed shows correct external source names

🤖 Generated with [Claude Code](https://claude.com/claude-code)