### PR TITLE
Fix custom URL HTML encoding in announcements (#249)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,18 @@ Also update the version number in:
 - `mayo-events-manager.php` (line 23: `MAYO_VERSION` constant)
 - `readme.txt` (line 8: `Stable tag`)
 - `package.json` (line 3: `version`)
+
+## Encoding Guidelines for REST API Data
+
+This codebase has had multiple encoding bugs (#41, #84, #109, #222, #249). Follow these rules when returning data via REST API:
+
+### URLs
+- **REST API/JSON context**: Use `esc_url_raw($url)` - preserves `&` characters
+- **HTML output context**: Use `esc_url($url)` - encodes `&` to `&amp;`
+
+### Text/Titles
+- **REST API/JSON context**: Use `html_entity_decode($text, ENT_QUOTES, 'UTF-8')`
+- **HTML output context**: Use `esc_html($text)` or `esc_attr($text)`
+
+### Why?
+WordPress escaping functions encode special characters for HTML safety. When this data goes through REST API → JSON → React, the HTML entities cause display issues or broken functionality.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "test": "phpunit",
         "test:unit": "phpunit --testsuite Unit",
         "lint": "phpcs *.php",
-        "lint:fix": "phpcbf *.php"
+        "lint:fix": "phpcbf *.php",
+        "lint:esc-url": "bash scripts/check-esc-url.sh",
+        "lint:all": ["@lint", "@lint:esc-url"]
     },
     "config": {
         "allow-plugins": {

--- a/includes/Announcement.php
+++ b/includes/Announcement.php
@@ -844,7 +844,7 @@ class Announcement {
             return [
                 'id' => $ref['id'] ?? 0,
                 'title' => sanitize_text_field($ref['title']),
-                'permalink' => esc_url($ref['url']),
+                'permalink' => esc_url_raw($ref['url']),
                 'icon' => isset($ref['icon']) ? sanitize_text_field($ref['icon']) : 'external',
                 'source' => [
                     'type' => 'custom',

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.8.5
+ * Version: 1.8.6
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.8.5');
+define('MAYO_VERSION', '1.8.6');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.9
-Stable tag: 1.8.5
+Stable tag: 1.8.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -186,6 +186,9 @@ This project is licensed under the GPL v2 or later.
    - Manage submitted events from the WordPress admin dashboard, where you can approve, edit, or delete events.
 
 == Changelog ==
+
+= 1.8.6 =
+* Fixed custom URLs in announcements having ampersands incorrectly HTML-encoded, causing links with query parameters to fail. [#249]
 
 = 1.8.5 =
 * Fixed external feed events not displaying service body names correctly. [#234]

--- a/scripts/check-esc-url.sh
+++ b/scripts/check-esc-url.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Check for esc_url() usage in REST API contexts (should use esc_url_raw() instead)
+# See issue #249 for context
+
+ERRORS=0
+
+# Check in includes/Rest directory
+if grep -rn "esc_url(" includes/Rest/ 2>/dev/null; then
+    echo "WARNING: Found esc_url() in includes/Rest/ - use esc_url_raw() for REST API contexts"
+    ERRORS=1
+fi
+
+# Check in Announcement.php (has REST-consumed methods)
+if grep -n "esc_url(" includes/Announcement.php 2>/dev/null | grep -v "esc_url_raw"; then
+    echo "WARNING: Found esc_url() in includes/Announcement.php - verify it's not used for REST API data"
+    ERRORS=1
+fi
+
+if [ $ERRORS -eq 0 ]; then
+    echo "No esc_url() issues found in REST contexts"
+fi
+
+exit $ERRORS

--- a/tests/Unit/AnnouncementTest.php
+++ b/tests/Unit/AnnouncementTest.php
@@ -430,6 +430,33 @@ class AnnouncementTest extends TestCase {
     }
 
     /**
+     * Test resolve_event_ref preserves URL query parameters (issue #249)
+     *
+     * Custom URLs with ampersands in query strings must not be HTML-encoded
+     * when returned via REST API.
+     */
+    public function testResolveEventRefPreservesUrlQueryParameters(): void {
+        $ref = [
+            'type' => 'custom',
+            'url' => 'https://example.com/link?id=123&key=GRP&app=resvlink',
+            'title' => 'Book Room',
+            'icon' => 'external'
+        ];
+
+        $result = Announcement::resolve_event_ref($ref);
+
+        $this->assertNotNull($result);
+        // URL should preserve literal & characters, not HTML entities
+        $this->assertEquals(
+            'https://example.com/link?id=123&key=GRP&app=resvlink',
+            $result['permalink']
+        );
+        // Explicitly verify no HTML encoding
+        $this->assertStringNotContainsString('&amp;', $result['permalink']);
+        $this->assertStringNotContainsString('&#038;', $result['permalink']);
+    }
+
+    /**
      * Test resolve_event_ref returns null for custom link without url
      */
     public function testResolveEventRefReturnsNullForCustomLinkWithoutUrl(): void {


### PR DESCRIPTION
## Summary
- Fixed custom URLs in announcement banners having ampersands (`&`) incorrectly HTML-encoded as `&#038;`, causing links with query parameters to fail
- Added regression test to prevent this issue from recurring
- Added encoding guidelines to CLAUDE.md documenting the pattern for REST API data
- Added `composer lint:esc-url` script to catch `esc_url()` usage in REST contexts

## Root Cause
The `resolve_event_ref()` method in `Announcement.php` used `esc_url()` which encodes `&` to `&amp;` for HTML contexts. When this passes through the REST API to JSON, it becomes `&#038;`.

**Fix:** Changed to `esc_url_raw()` which preserves `&` characters while still providing the same security (protocol validation, dangerous character removal).

## Test plan
- [x] All 514 PHPUnit tests pass (including new regression test)
- [x] Create announcement with custom link containing query params (e.g., `https://httpbin.org/get?foo=1&bar=2`)
- [x] Verify link works correctly on frontend
- [x] Verify REST API response shows literal `&` not `&#038;`

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)