### PR TITLE
Add server health check for missing PHP curl extension

### DIFF
--- a/assets/js/src/components/admin/Settings.js
+++ b/assets/js/src/components/admin/Settings.js
@@ -105,7 +105,8 @@ const Settings = () => {
                 setSettings({
                     bmlt_root_server: response.bmlt_root_server || '',
                     notification_email: response.notification_email || '',
-                    default_service_bodies: response.default_service_bodies || ''
+                    default_service_bodies: response.default_service_bodies || '',
+                    server_info: response.server_info || null
                 });
                 setExternalSources(Array.isArray(response.external_sources) ? response.external_sources : []);
 
@@ -338,6 +339,18 @@ const Settings = () => {
             <Notice status="warning" isDismissible={false}>
                 <p><strong>Important:</strong> This plugin requires Pretty Permalinks to be enabled for the REST API to function correctly. If you're experiencing 404 errors when accessing external source or settings  BMLT server, please ensure your WordPress site is using Pretty Permalinks (Settings → Permalinks) and not the "Plain" setting.</p>
             </Notice>
+
+            {settings.server_info && !settings.server_info.curl_available && (
+                <Notice status="warning" isDismissible={false}>
+                    <p><strong>Performance Warning:</strong> The PHP curl extension is not installed. External source requests will be significantly slower. Ask your hosting provider to install the php-curl extension for PHP {settings.server_info.php_version}.</p>
+                </Notice>
+            )}
+
+            {settings.server_info && settings.server_info.curl_available && (
+                <Notice status="success" isDismissible={false}>
+                    <p>PHP {settings.server_info.php_version} with curl {settings.server_info.curl_version} detected.</p>
+                </Notice>
+            )}
             
             {error && (
                 <Notice status="error" isDismissible={true} onRemove={() => setError(null)}>

--- a/includes/Rest/SettingsController.php
+++ b/includes/Rest/SettingsController.php
@@ -38,7 +38,7 @@ class SettingsController {
         $settings = get_option('mayo_settings', []);
         $external_sources = get_option('mayo_external_sources', []);
 
-        return new \WP_REST_Response([
+        $response_data = [
             'bmlt_root_server' => $settings['bmlt_root_server'] ?? '',
             'notification_email' => $settings['notification_email'] ?? '',
             'default_service_bodies' => $settings['default_service_bodies'] ?? '',
@@ -47,7 +47,17 @@ class SettingsController {
             'subscription_tags' => $settings['subscription_tags'] ?? [],
             'subscription_service_bodies' => $settings['subscription_service_bodies'] ?? [],
             'subscription_new_option_behavior' => $settings['subscription_new_option_behavior'] ?? 'opt_in'
-        ]);
+        ];
+
+        if (current_user_can('manage_options')) {
+            $response_data['server_info'] = [
+                'php_version'    => PHP_VERSION,
+                'curl_available' => extension_loaded('curl'),
+                'curl_version'   => extension_loaded('curl') ? curl_version()['version'] : null,
+            ];
+        }
+
+        return new \WP_REST_Response($response_data);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ This project is licensed under the GPL v2 or later.
 * Changed external source event type dropdown from "Select an event type" to "All Event Types" to clarify that leaving it blank fetches all types.
 * Added support for comma-separated event types in the REST API (e.g., `event_type=Activity,Service`), enabling a single external source to fetch multiple event types in one request.
 * Fixed admin events list page taking minutes to load when many events exist by caching service body lookups instead of making an HTTP request per row.
+* Added server health check warning on settings page when PHP curl extension is missing, which causes significantly slower external source requests.
 
 = 1.8.7 =
 * Fixed announcement form flyer upload field never appearing even when `show_flyer="true"` shortcode attribute was set. [#252]


### PR DESCRIPTION
## Summary
- Adds `server_info` (PHP version, curl availability/version) to the settings API response for admin users only
- Displays a warning notice on the settings page when the PHP curl extension is missing
- Displays a success notice with PHP and curl version info when curl is available
- Prevents hours of debugging slow page loads caused by WordPress falling back to PHP streams without curl

## Context
We spent hours debugging why na-wt.org's events page took ~33s to load. The root cause was PHP 8.4-FPM missing the curl extension — WordPress fell back to PHP streams for outbound HTTP requests, adding ~5s per call. This was invisible to the admin.

## Test plan
- [ ] With curl enabled: settings page shows green success notice with PHP/curl versions
- [ ] With curl disabled: settings page shows yellow warning with instructions
- [ ] Non-admin API requests to `/settings` do not include `server_info`
- [ ] `composer test` passes (514 tests)
- [ ] `npm run build` succeeds
- [ ] `composer lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)