### PR TITLE
Fix release notes fetching from stale master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate Release Notes 📝
         if: github.ref_type == 'tag'
         run: |
-          curl -LO https://raw.githubusercontent.com/bmlt-enabled/release-notes-tool/master/gh-release-notes.sh
+          curl -LO https://raw.githubusercontent.com/bmlt-enabled/release-notes-tool/main/gh-release-notes.sh
           chmod +x gh-release-notes.sh
           ./gh-release-notes.sh readme.txt "wp"
           RELEASE_TYPE=$(if [[ "$GITHUB_REF_NAME" =~ "beta" ]]; then echo "true"; else echo "false"; fi)

--- a/readme.txt
+++ b/readme.txt
@@ -187,10 +187,8 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
-= 1.8.9 =
-* Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.
-
 = 1.8.8 =
+* Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.
 * Added copy-to-clipboard button for external source IDs in Settings, making IDs easier to select and copy. [#254]
 * Improved external source layout with ID displayed in a distinct box on its own row.
 * Added diagnostic timing instrumentation to the events API for debugging slow external source requests. Append `&debug=1` to see per-call timing breakdown.

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,9 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.8.9 =
+* Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.
+
 = 1.8.8 =
 * Added copy-to-clipboard button for external source IDs in Settings, making IDs easier to select and copy. [#254]
 * Improved external source layout with ID displayed in a distinct box on its own row.


### PR DESCRIPTION
## Summary
- Changed release workflow to fetch `release-notes-tool` from `main` instead of `master`
- The `master` branch is stale and still has the broken sed pattern that truncates changelog entries containing `=` characters

## Problem
The 1.8.8 GitHub Release only contained 2 of 8 changelog entries. The fix to the sed pattern ([bmlt-enabled/release-notes-tool#2](https://github.com/bmlt-enabled/release-notes-tool/pull/2)) was merged to `main`, but this workflow was curling from `master`.

## Test plan
- [ ] After merging, delete and re-tag 1.8.8 to verify all 8 changelog entries appear in the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)