### PR TITLE
Fix mayo-public script/style cache never invalidating across upgrades

### DIFF
--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -24,7 +24,7 @@ class Frontend {
                     'wp-i18n',
                     'wp-api-fetch'
                 ],
-                '1.0',
+                defined('MAYO_VERSION') ? MAYO_VERSION : '1.0',
                 true
             );
         });
@@ -238,7 +238,7 @@ class Frontend {
                     'wp-i18n',
                     'wp-api-fetch'
                 ],
-                '1.0',
+                defined('MAYO_VERSION') ? MAYO_VERSION : '1.0',
                 true
             );
 
@@ -247,7 +247,7 @@ class Frontend {
                 'mayo-public',
                 plugin_dir_url(__FILE__) . '../assets/css/public.css',
                 ['wp-components'],
-                '1.0'
+                defined('MAYO_VERSION') ? MAYO_VERSION : '1.0'
             );
             wp_enqueue_style('dashicons');
         }


### PR DESCRIPTION
- The mayo-public script and the mayo-public style in includes/Frontend.php were registered with a hardcoded `'1.0'` version, so WordPress always emitted `?ver=1.0` on the bundle and CSS URLs.
- Browsers, CDNs (e.g. Cloudflare), and JS-combine plugins (WP Rocket, LiteSpeed, Autoptimize) cache by URL, so users kept seeing the old bundle/CSS even after a plugin upgrade.
- This swaps the hardcoded `'1.0'` for `defined('MAYO_VERSION') ? MAYO_VERSION : '1.0'`: the same pattern already used in mayo-events-manager.php:187, Admin.php:151, and Admin.php:161. Cache busts on every release.