### PR TITLE
Release 1.8.9

### DIFF
--- a/assets/js/src/components/admin/EventBlockEditorSidebar.js
+++ b/assets/js/src/components/admin/EventBlockEditorSidebar.js
@@ -180,7 +180,8 @@ const EventBlockEditorSidebar = () => {
                     options={[
                         { label: 'Select Event Type', value: '' },
                         { label: 'Service', value: 'Service' },
-                        { label: 'Activity', value: 'Activity' }
+                        { label: 'Activity', value: 'Activity' },
+                        { label: 'Celebration', value: 'Celebration' }
                     ]}
                     onChange={value => updateMetaValue('event_type', value)}
                     __nextHasNoMarginBottom={true}

--- a/assets/js/src/components/admin/Settings.js
+++ b/assets/js/src/components/admin/Settings.js
@@ -523,7 +523,8 @@ const Settings = () => {
                                 options={[
                                     { label: 'All Event Types', value: '' },
                                     { label: 'Activity', value: 'Activity' },
-                                    { label: 'Service', value: 'Service' }
+                                    { label: 'Service', value: 'Service' },
+                                    { label: 'Celebration', value: 'Celebration' }
                                 ]}
                                 onChange={(value) => {
                                     setCurrentSource({...currentSource, event_type: value});

--- a/assets/js/src/components/public/EventForm.js
+++ b/assets/js/src/components/public/EventForm.js
@@ -517,6 +517,7 @@ const EventForm = () => {
                         <option value="">Select Event Type</option>
                         <option value="Service">Service</option>
                         <option value="Activity">Activity</option>
+                        <option value="Celebration">Celebration</option>
                     </select>
                 </div>
 

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -82,7 +82,7 @@ class Frontend {
             'categories' => '',  // Comma-separated category slugs
             'category_relation' => 'OR',  // AND or OR - how to match multiple categories
             'tags' => '',       // Comma-separated tag slugs
-            'event_type' => '',  // Single event type (Service, Activity)
+            'event_type' => '',  // Single event type (Service, Activity, Celebration)
             'status' => 'publish',  // Single event status (publish, pending)
             'service_body' => '',  // Comma-separated service body IDs
             'source_ids' => '',  // Comma-separated source IDs

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.8.8
+ * Version: 1.8.9
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app
@@ -20,7 +20,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.8.8');
+define('MAYO_VERSION', '1.8.9');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.8.8 =
+* Added "Celebration" as a third event type option, allowing users to mark clean-time celebration dates/times alongside Service and Activity events.
 * Fixed archive mode incorrectly showing future multi-day events. Archive now requires both start and end dates to be before today. [#265]
 * Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.
 * Added copy-to-clipboard button for external source IDs in Settings, making IDs easier to select and copy. [#254]

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 6.9
-Stable tag: 1.8.8
+Stable tag: 1.8.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -187,9 +187,12 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
-= 1.8.8 =
+= 1.8.9 =
 * Added "Celebration" as a third event type option, allowing users to mark clean-time celebration dates/times alongside Service and Activity events.
 * Fixed archive mode incorrectly showing future multi-day events. Archive now requires both start and end dates to be before today. [#265]
+* Fixed mayo-public script and style cache never invalidating across plugin upgrades by using MAYO_VERSION for cache-busting. [#264]
+
+= 1.8.8 =
 * Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.
 * Added copy-to-clipboard button for external source IDs in Settings, making IDs easier to select and copy. [#254]
 * Improved external source layout with ID displayed in a distinct box on its own row.


### PR DESCRIPTION
## Summary
- Adds "Celebration" as a third event type alongside Service and Activity (from #263)
- Fixes archive mode incorrectly showing future multi-day events (#266 / #265)
- Fixes mayo-public script/style cache never invalidating across upgrades (#264)
- Bumps version to 1.8.9

## Changelog
```
= 1.8.9 =
* Added "Celebration" as a third event type option, allowing users to mark clean-time celebration dates/times alongside Service and Activity events.
* Fixed archive mode incorrectly showing future multi-day events. Archive now requires both start and end dates to be before today. [#265]
* Fixed mayo-public script and style cache never invalidating across plugin upgrades by using MAYO_VERSION for cache-busting. [#264]
```

## Test plan
- [ ] Verify celebration event type appears in all three dropdowns (admin, public form, external source settings)
- [ ] Verify archive mode no longer shows future multi-day events
- [ ] Verify frontend JS/CSS cache-busts correctly with the plugin version
- [ ] Smoke test existing event creation and listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)