### PR TITLE
Fix calendar not loading on CDN-cached pages

### DIFF
--- a/assets/js/src/components/admin/AnnouncementEditor.js
+++ b/assets/js/src/components/admin/AnnouncementEditor.js
@@ -78,7 +78,7 @@ const EventSearchModal = ({ isOpen, onClose, onSelectEvent, onRemoveEvent, linke
                 params.append('search', searchQuery);
             }
 
-            const response = await apiFetch(`/events/search-all?${params.toString()}`);
+            const response = await apiFetch(`/events/search-all?${params.toString()}`, { authenticated: true });
             const newEvents = response.events || [];
 
             if (append) {
@@ -752,7 +752,7 @@ const AnnouncementEditor = () => {
                     } else if (ref.type === 'external') {
                         // For external events, we need to fetch from the external source
                         try {
-                            const response = await apiFetch(`/events/search-all?per_page=100`);
+                            const response = await apiFetch(`/events/search-all?per_page=100`, { authenticated: true });
                             const externalEvent = (response.events || []).find(
                                 e => e.source.type === 'external' &&
                                     e.source.id === ref.source_id &&

--- a/assets/js/src/components/admin/Subscribers.js
+++ b/assets/js/src/components/admin/Subscribers.js
@@ -151,7 +151,7 @@ const Subscribers = () => {
         const fetchData = async () => {
             try {
                 const [subscribersData, optionsData] = await Promise.all([
-                    apiFetch('/subscribers'),
+                    apiFetch('/subscribers', { authenticated: true }),
                     apiFetch('/subscription-options')
                 ]);
                 setSubscribers(subscribersData);
@@ -173,7 +173,7 @@ const Subscribers = () => {
                 body: JSON.stringify(data)
             });
             // Refresh subscriber list
-            const updated = await apiFetch('/subscribers');
+            const updated = await apiFetch('/subscribers', { authenticated: true });
             setSubscribers(updated);
             setEditingSubscriber(null);
         } catch (err) {

--- a/assets/js/src/util.js
+++ b/assets/js/src/util.js
@@ -127,36 +127,38 @@ export const apiFetch = async (endpoint, options = {}) => {
         baseUrl += '/';
     }
     const url = `${baseUrl}event-manager/v1${endpoint}`;
-    
-    // Check for nonce in various places
-    let nonce = '';
-    
-    // First check if mayoApiSettings exists (our plugin's settings)
-    if (window.mayoApiSettings && window.mayoApiSettings.nonce) {
-        nonce = window.mayoApiSettings.nonce;
-    } 
-    // Fallback to WordPress core's wpApiSettings
-    else if (window.wpApiSettings && window.wpApiSettings.nonce) {
-        nonce = window.wpApiSettings.nonce;
+
+    const method = (options.method || 'GET').toUpperCase();
+    const { authenticated, ...restOptions } = options;
+
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+
+    // Only send nonce for write operations or when explicitly requested.
+    // Public GET endpoints don't need it, and sending a stale nonce
+    // (from CDN-cached pages) causes 403 errors.
+    if (method !== 'GET' || authenticated) {
+        const nonce = window.mayoApiSettings?.nonce || window.wpApiSettings?.nonce || '';
+        if (nonce) {
+            headers['X-WP-Nonce'] = nonce;
+        }
     }
-    
+
     const defaultOptions = {
         credentials: 'same-origin',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-WP-Nonce': nonce
-        }
+        headers
     };
-    
-    const fetchOptions = { ...defaultOptions, ...options };
-    
+
+    const fetchOptions = { ...defaultOptions, ...restOptions };
+
     try {
         const response = await fetch(url, fetchOptions);
-        
+
         if (!response.ok) {
             throw new Error(`API error: ${response.status} ${response.statusText}`);
         }
-        
+
         return await response.json();
     } catch (error) {
         console.error('API fetch error:', error);

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ This project is licensed under the GPL v2 or later.
 * Added "Celebration" as a third event type option, allowing users to mark clean-time celebration dates/times alongside Service and Activity events.
 * Fixed archive mode incorrectly showing future multi-day events. Archive now requires both start and end dates to be before today. [#265]
 * Fixed mayo-public script and style cache never invalidating across plugin upgrades by using MAYO_VERSION for cache-busting. [#264]
+* Fixed calendar/event list failing to load on CDN-cached pages due to stale nonce in API requests. Public GET endpoints no longer send X-WP-Nonce header. [#271]
 
 = 1.8.8 =
 * Fixed release workflow fetching release-notes-tool from stale `master` branch instead of `main`, which caused GitHub Release notes to be truncated.


### PR DESCRIPTION
## Summary

- Stop sending `X-WP-Nonce` header on GET requests from the public frontend. Public REST endpoints don't need authentication, and sending a stale nonce (from CDN-cached pages) causes WordPress to return 403.
- Add `{ authenticated: true }` option to `apiFetch` for admin GET requests that require cookie authentication.
- Write operations (POST/PUT/DELETE) continue to send the nonce for CSRF protection.

Closes #271

## Test plan

- [ ] Load the calendar/event list page — events should load successfully
- [ ] Submit an event via the form — should still work (POST sends nonce)
- [ ] Verify admin Subscribers page loads subscriber list
- [ ] Verify admin Announcement Editor event search works
- [ ] Simulate stale nonce scenario: manually set `window.mayoApiSettings.nonce` to an invalid value in browser console, then reload the event list — it should still load (GET requests don't send the nonce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)