### PR TITLE
Add display filter dropdowns to event list/calendar [#251]

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1873,6 +1873,65 @@
     margin-bottom: 1rem;
 }
 
+.mayo-event-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: flex-end;
+    margin-bottom: 1rem;
+    padding: 0.75rem;
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+}
+
+.mayo-event-filter {
+    display: flex;
+    flex-direction: column;
+    min-width: 160px;
+    flex: 1 1 160px;
+}
+
+.mayo-event-filter-label {
+    font-size: 0.85em;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    color: #1d2327;
+}
+
+.mayo-event-filter-select {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #8c8f94;
+    border-radius: 3px;
+    background: #fff;
+    font-size: 0.95em;
+    line-height: 1.4;
+    max-width: 100%;
+}
+
+.mayo-event-filter-select:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: 2px solid transparent;
+}
+
+.mayo-event-filter-clear {
+    align-self: flex-end;
+    background: transparent;
+    border: 1px solid #8c8f94;
+    border-radius: 3px;
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    color: #1d2327;
+    font-size: 0.9em;
+}
+
+.mayo-event-filter-clear:hover {
+    background: #fff;
+    border-color: #2271b1;
+    color: #2271b1;
+}
+
 .mayo-view-toggle {
     display: flex;
 }

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1875,9 +1875,8 @@
 
 .mayo-event-filters {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1rem;
-    align-items: flex-end;
+    flex-direction: column;
+    gap: 0.75rem;
     margin-bottom: 1rem;
     padding: 0.75rem;
     background: #f6f7f7;
@@ -1885,45 +1884,68 @@
     border-radius: 4px;
 }
 
-.mayo-event-filter {
+.mayo-event-filter-group {
     display: flex;
     flex-direction: column;
-    min-width: 160px;
-    flex: 1 1 160px;
+    gap: 0.375rem;
 }
 
 .mayo-event-filter-label {
     font-size: 0.85em;
     font-weight: 600;
-    margin-bottom: 0.25rem;
     color: #1d2327;
 }
 
-.mayo-event-filter-select {
-    padding: 0.4rem 0.5rem;
-    border: 1px solid #8c8f94;
-    border-radius: 3px;
-    background: #fff;
-    font-size: 0.95em;
-    line-height: 1.4;
-    max-width: 100%;
+.mayo-event-filter-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
 }
 
-.mayo-event-filter-select:focus {
+.mayo-event-filter-pill {
+    appearance: none;
+    background: #fff;
+    border: 1px solid #8c8f94;
+    border-radius: 999px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.9em;
+    line-height: 1.2;
+    color: #1d2327;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.mayo-event-filter-pill:hover {
     border-color: #2271b1;
-    box-shadow: 0 0 0 1px #2271b1;
-    outline: 2px solid transparent;
+    color: #2271b1;
+}
+
+.mayo-event-filter-pill:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.mayo-event-filter-pill[aria-pressed="true"] {
+    background: #2271b1;
+    border-color: #2271b1;
+    color: #fff;
+}
+
+.mayo-event-filter-pill[aria-pressed="true"]:hover {
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
 }
 
 .mayo-event-filter-clear {
-    align-self: flex-end;
+    align-self: flex-start;
     background: transparent;
     border: 1px solid #8c8f94;
     border-radius: 3px;
-    padding: 0.4rem 0.75rem;
+    padding: 0.35rem 0.75rem;
     cursor: pointer;
     color: #1d2327;
-    font-size: 0.9em;
+    font-size: 0.85em;
 }
 
 .mayo-event-filter-clear:hover {

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1893,12 +1893,12 @@
 }
 
 .mayo-event-filter-add {
-    padding: 0.2rem 0.4rem;
+    padding: 0.15rem 0.35rem;
     border: 1px solid #8c8f94;
     border-radius: 3px;
     background: #fff;
-    font-size: 0.8em;
-    line-height: 1.3;
+    font-size: 0.7em;
+    line-height: 1.25;
     color: #1d2327;
     max-width: 100%;
 }
@@ -1918,11 +1918,11 @@
     display: inline-flex;
     align-items: center;
     gap: 0.2rem;
-    padding: 0.15rem 0.3rem 0.15rem 0.55rem;
+    padding: 0.1rem 0.25rem 0.1rem 0.5rem;
     background: #2271b1;
     color: #fff;
     border-radius: 999px;
-    font-size: 0.75em;
+    font-size: 0.65em;
     line-height: 1.2;
 }
 
@@ -1955,10 +1955,10 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 3px;
-    padding: 0.15rem 0.35rem;
+    padding: 0.1rem 0.3rem;
     cursor: pointer;
     line-height: 1;
-    font-size: 0.95em;
+    font-size: 0.85em;
 }
 
 .mayo-event-filter-clear:hover {

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1877,78 +1877,156 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
     margin-bottom: 1rem;
-    padding: 0.5rem 0.75rem;
+    padding: 0.4rem 0.5rem;
     background: #f6f7f7;
     border: 1px solid #dcdcde;
     border-radius: 4px;
 }
 
-.mayo-event-filter-group {
+.mayo-event-filter-pill-wrap {
+    position: relative;
     display: inline-flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.375rem;
 }
 
-.mayo-event-filter-add {
-    padding: 0.15rem 0.35rem;
-    border: 1px solid #8c8f94;
-    border-radius: 3px;
+.mayo-event-filter-pill {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.65rem;
     background: #fff;
-    font-size: 0.7em;
-    line-height: 1.25;
+    border: 1px solid #8c8f94;
+    border-radius: 999px;
     color: #1d2327;
-    max-width: 100%;
+    font-size: 0.7em;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.mayo-event-filter-add:focus {
+.mayo-event-filter-pill:hover {
     border-color: #2271b1;
-    box-shadow: 0 0 0 1px #2271b1;
-    outline: 2px solid transparent;
+    color: #2271b1;
 }
 
-.mayo-event-filter-add:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
+.mayo-event-filter-pill:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
 }
 
-.mayo-event-filter-chip {
+.mayo-event-filter-pill.is-open,
+.mayo-event-filter-pill.has-selection {
+    border-color: #1d2327;
+    border-width: 2px;
+    padding: calc(0.15rem - 1px) calc(0.65rem - 1px);
+}
+
+.mayo-event-filter-pill-count {
     display: inline-flex;
     align-items: center;
-    gap: 0.2rem;
-    padding: 0.1rem 0.25rem 0.1rem 0.5rem;
+    justify-content: center;
+    min-width: 1.1em;
+    padding: 0 0.3em;
     background: #2271b1;
     color: #fff;
     border-radius: 999px;
-    font-size: 0.65em;
-    line-height: 1.2;
+    font-size: 0.85em;
+    line-height: 1.4;
 }
 
-.mayo-event-filter-chip-label {
-    white-space: nowrap;
+.mayo-event-filter-panel {
+    position: absolute;
+    top: calc(100% + 0.3rem);
+    left: 0;
+    z-index: 50;
+    min-width: 200px;
+    max-width: 280px;
+    max-height: 320px;
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+    padding: 0.4rem 0;
 }
 
-.mayo-event-filter-chip-remove {
+.mayo-event-filter-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.1rem 0.75rem 0.35rem;
+    border-bottom: 1px solid #f0f0f1;
+}
+
+.mayo-event-filter-panel-title {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.mayo-event-filter-panel-close {
     appearance: none;
     background: transparent;
     border: none;
-    color: #fff;
     cursor: pointer;
-    font-size: 1em;
+    font-size: 1.05em;
     line-height: 1;
-    padding: 0 0.2rem;
-    border-radius: 50%;
+    padding: 0.1rem 0.3rem;
+    color: #50575e;
+    border-radius: 3px;
 }
 
-.mayo-event-filter-chip-remove:hover {
-    background: rgba(255, 255, 255, 0.25);
+.mayo-event-filter-panel-close:hover {
+    background: #f0f0f1;
+    color: #1d2327;
 }
 
-.mayo-event-filter-chip-remove:focus-visible {
-    outline: 2px solid #fff;
-    outline-offset: 1px;
+.mayo-event-filter-panel-options {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem 0;
+}
+
+.mayo-event-filter-panel-options li {
+    margin: 0;
+}
+
+.mayo-event-filter-option {
+    appearance: none;
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8em;
+    line-height: 1.3;
+    color: #1d2327;
+    cursor: pointer;
+}
+
+.mayo-event-filter-option:hover {
+    background: #f0f0f1;
+}
+
+.mayo-event-filter-option.is-active {
+    background: #2271b1;
+    color: #fff;
+}
+
+.mayo-event-filter-option.is-active:hover {
+    background: #135e96;
+}
+
+.mayo-event-filter-option:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: -2px;
 }
 
 .mayo-event-filter-clear {

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1893,12 +1893,12 @@
 }
 
 .mayo-event-filter-add {
-    padding: 0.3rem 0.5rem;
+    padding: 0.2rem 0.4rem;
     border: 1px solid #8c8f94;
     border-radius: 3px;
     background: #fff;
-    font-size: 0.9em;
-    line-height: 1.4;
+    font-size: 0.8em;
+    line-height: 1.3;
     color: #1d2327;
     max-width: 100%;
 }
@@ -1917,12 +1917,12 @@
 .mayo-event-filter-chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.2rem 0.4rem 0.2rem 0.65rem;
+    gap: 0.2rem;
+    padding: 0.15rem 0.3rem 0.15rem 0.55rem;
     background: #2271b1;
     color: #fff;
     border-radius: 999px;
-    font-size: 0.85em;
+    font-size: 0.75em;
     line-height: 1.2;
 }
 
@@ -1936,9 +1936,9 @@
     border: none;
     color: #fff;
     cursor: pointer;
-    font-size: 1.1em;
+    font-size: 1em;
     line-height: 1;
-    padding: 0 0.25rem;
+    padding: 0 0.2rem;
     border-radius: 50%;
 }
 
@@ -1955,10 +1955,10 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 3px;
-    padding: 0.2rem 0.4rem;
+    padding: 0.15rem 0.35rem;
     cursor: pointer;
     line-height: 1;
-    font-size: 1.05em;
+    font-size: 0.95em;
 }
 
 .mayo-event-filter-clear:hover {

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1876,7 +1876,7 @@
 .mayo-event-filters {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.5rem;
     margin-bottom: 1rem;
     padding: 0.75rem;
     background: #f6f7f7;
@@ -1886,55 +1886,83 @@
 
 .mayo-event-filter-group {
     display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .mayo-event-filter-label {
     font-size: 0.85em;
     font-weight: 600;
     color: #1d2327;
+    min-width: 100px;
 }
 
-.mayo-event-filter-pills {
+.mayo-event-filter-controls {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 0.375rem;
+    flex: 1 1 auto;
 }
 
-.mayo-event-filter-pill {
-    appearance: none;
-    background: #fff;
+.mayo-event-filter-add {
+    padding: 0.3rem 0.5rem;
     border: 1px solid #8c8f94;
-    border-radius: 999px;
-    padding: 0.3rem 0.75rem;
+    border-radius: 3px;
+    background: #fff;
     font-size: 0.9em;
-    line-height: 1.2;
+    line-height: 1.4;
     color: #1d2327;
-    cursor: pointer;
-    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    max-width: 100%;
 }
 
-.mayo-event-filter-pill:hover {
+.mayo-event-filter-add:focus {
     border-color: #2271b1;
-    color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: 2px solid transparent;
 }
 
-.mayo-event-filter-pill:focus-visible {
-    outline: 2px solid #2271b1;
-    outline-offset: 2px;
+.mayo-event-filter-add:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
-.mayo-event-filter-pill[aria-pressed="true"] {
+.mayo-event-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.4rem 0.2rem 0.65rem;
     background: #2271b1;
-    border-color: #2271b1;
     color: #fff;
+    border-radius: 999px;
+    font-size: 0.85em;
+    line-height: 1.2;
 }
 
-.mayo-event-filter-pill[aria-pressed="true"]:hover {
-    background: #135e96;
-    border-color: #135e96;
+.mayo-event-filter-chip-label {
+    white-space: nowrap;
+}
+
+.mayo-event-filter-chip-remove {
+    appearance: none;
+    background: transparent;
+    border: none;
     color: #fff;
+    cursor: pointer;
+    font-size: 1.1em;
+    line-height: 1;
+    padding: 0 0.25rem;
+    border-radius: 50%;
+}
+
+.mayo-event-filter-chip-remove:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.mayo-event-filter-chip-remove:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 1px;
 }
 
 .mayo-event-filter-clear {
@@ -1942,7 +1970,7 @@
     background: transparent;
     border: 1px solid #8c8f94;
     border-radius: 3px;
-    padding: 0.35rem 0.75rem;
+    padding: 0.3rem 0.65rem;
     cursor: pointer;
     color: #1d2327;
     font-size: 0.85em;

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1952,20 +1952,23 @@
 }
 
 .mayo-event-filter-clear {
-    align-self: flex-start;
     background: transparent;
-    border: 1px solid #8c8f94;
+    border: 1px solid transparent;
     border-radius: 3px;
-    padding: 0.3rem 0.65rem;
+    padding: 0.2rem 0.4rem;
     cursor: pointer;
-    color: #1d2327;
-    font-size: 0.85em;
+    line-height: 1;
+    font-size: 1.05em;
 }
 
 .mayo-event-filter-clear:hover {
     background: #fff;
     border-color: #2271b1;
-    color: #2271b1;
+}
+
+.mayo-event-filter-clear:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 1px;
 }
 
 .mayo-view-toggle {

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1875,35 +1875,21 @@
 
 .mayo-event-filters {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: center;
     gap: 0.5rem;
     margin-bottom: 1rem;
-    padding: 0.75rem;
+    padding: 0.5rem 0.75rem;
     background: #f6f7f7;
     border: 1px solid #dcdcde;
     border-radius: 4px;
 }
 
 .mayo-event-filter-group {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.mayo-event-filter-label {
-    font-size: 0.85em;
-    font-weight: 600;
-    color: #1d2327;
-    min-width: 100px;
-}
-
-.mayo-event-filter-controls {
-    display: flex;
+    display: inline-flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.375rem;
-    flex: 1 1 auto;
 }
 
 .mayo-event-filter-add {

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -3,27 +3,23 @@ import { __, sprintf } from '@wordpress/i18n';
 const FACET_DEFS = [
     {
         key: 'event_type',
+        /* translators: dropdown title/placeholder for the event-type filter */
         i18nLabel: () => __('Event Type', 'mayo-events-manager'),
-        /* translators: dropdown placeholder for the event-type filter */
-        i18nPlaceholder: () => __('Filter by event type…', 'mayo-events-manager'),
     },
     {
         key: 'service_body',
+        /* translators: dropdown title/placeholder for the service-body filter */
         i18nLabel: () => __('Service Body', 'mayo-events-manager'),
-        /* translators: dropdown placeholder for the service-body filter */
-        i18nPlaceholder: () => __('Filter by service body…', 'mayo-events-manager'),
     },
     {
         key: 'categories',
+        /* translators: dropdown title/placeholder for the category filter */
         i18nLabel: () => __('Category', 'mayo-events-manager'),
-        /* translators: dropdown placeholder for the category filter */
-        i18nPlaceholder: () => __('Filter by category…', 'mayo-events-manager'),
     },
     {
         key: 'tags',
+        /* translators: dropdown title/placeholder for the tag filter */
         i18nLabel: () => __('Tag', 'mayo-events-manager'),
-        /* translators: dropdown placeholder for the tag filter */
-        i18nPlaceholder: () => __('Filter by tag…', 'mayo-events-manager'),
     },
 ];
 
@@ -74,6 +70,7 @@ const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilter
                             id={selectId}
                             className="mayo-event-filter-add"
                             aria-label={def.i18nLabel()}
+                            title={def.i18nLabel()}
                             value=""
                             onChange={(e) => {
                                 if (e.target.value) {
@@ -83,7 +80,7 @@ const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilter
                             }}
                             disabled={availableOptions.length === 0}
                         >
-                            <option value="">{def.i18nPlaceholder()}</option>
+                            <option value="">{def.i18nLabel()}</option>
                             {availableOptions.map(option => (
                                 <option key={option.value} value={option.value}>
                                     {option.label}
@@ -118,8 +115,10 @@ const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilter
                     type="button"
                     className="mayo-event-filter-clear"
                     onClick={onClear}
+                    title={__('Clear filters', 'mayo-events-manager')}
+                    aria-label={__('Clear filters', 'mayo-events-manager')}
                 >
-                    {__('Clear filters', 'mayo-events-manager')}
+                    <span aria-hidden="true">🧹</span>
                 </button>
             )}
         </div>

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -70,50 +70,46 @@ const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilter
                 const selectId = `mayo-event-filter-${def.key}`;
                 return (
                     <div key={def.key} className="mayo-event-filter-group">
-                        <label htmlFor={selectId} className="mayo-event-filter-label">
-                            {def.i18nLabel()}
-                        </label>
-                        <div className="mayo-event-filter-controls">
-                            <select
-                                id={selectId}
-                                className="mayo-event-filter-add"
-                                value=""
-                                onChange={(e) => {
-                                    if (e.target.value) {
-                                        onAdd(def.key, e.target.value);
-                                        e.target.value = '';
-                                    }
-                                }}
-                                disabled={availableOptions.length === 0}
-                            >
-                                <option value="">{def.i18nPlaceholder()}</option>
-                                {availableOptions.map(option => (
-                                    <option key={option.value} value={option.value}>
-                                        {option.label}
-                                    </option>
-                                ))}
-                            </select>
-                            {activeValues.map(value => {
-                                const label = valueToLabel.get(value) || value;
-                                return (
-                                    <span key={value} className="mayo-event-filter-chip">
-                                        <span className="mayo-event-filter-chip-label">{label}</span>
-                                        <button
-                                            type="button"
-                                            className="mayo-event-filter-chip-remove"
-                                            onClick={() => onRemove(def.key, value)}
-                                            aria-label={sprintf(
-                                                /* translators: %s: filter value being removed */
-                                                __('Remove filter %s', 'mayo-events-manager'),
-                                                label
-                                            )}
-                                        >
-                                            ×
-                                        </button>
-                                    </span>
-                                );
-                            })}
-                        </div>
+                        <select
+                            id={selectId}
+                            className="mayo-event-filter-add"
+                            aria-label={def.i18nLabel()}
+                            value=""
+                            onChange={(e) => {
+                                if (e.target.value) {
+                                    onAdd(def.key, e.target.value);
+                                    e.target.value = '';
+                                }
+                            }}
+                            disabled={availableOptions.length === 0}
+                        >
+                            <option value="">{def.i18nPlaceholder()}</option>
+                            {availableOptions.map(option => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                        {activeValues.map(value => {
+                            const label = valueToLabel.get(value) || value;
+                            return (
+                                <span key={value} className="mayo-event-filter-chip">
+                                    <span className="mayo-event-filter-chip-label">{label}</span>
+                                    <button
+                                        type="button"
+                                        className="mayo-event-filter-chip-remove"
+                                        onClick={() => onRemove(def.key, value)}
+                                        aria-label={sprintf(
+                                            /* translators: %s: filter value being removed */
+                                            __('Remove filter %s', 'mayo-events-manager'),
+                                            label
+                                        )}
+                                    >
+                                        ×
+                                    </button>
+                                </span>
+                            );
+                        })}
                     </div>
                 );
             })}

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -1,0 +1,83 @@
+import { __ } from '@wordpress/i18n';
+
+const FACET_DEFS = [
+    { key: 'event_type', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Event Type', 'mayo-events-manager') },
+    { key: 'service_body', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Service Body', 'mayo-events-manager') },
+    { key: 'categories', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Category', 'mayo-events-manager') },
+    { key: 'tags', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Tag', 'mayo-events-manager') },
+];
+
+const normalizeOptions = (key, facets) => {
+    if (key === 'event_type') {
+        return (facets?.event_types || []).map(type => ({ value: type, label: type }));
+    }
+    if (key === 'service_body') {
+        return (facets?.service_bodies || []).map(body => ({
+            value: String(body.id),
+            label: body.name,
+            sourceId: body.source_id,
+        }));
+    }
+    if (key === 'categories') {
+        return (facets?.categories || []).map(term => ({ value: term.slug, label: term.name }));
+    }
+    if (key === 'tags') {
+        return (facets?.tags || []).map(term => ({ value: term.slug, label: term.name }));
+    }
+    return [];
+};
+
+const EventFilters = ({ facets, selected, onChange, lockedFilters }) => {
+    const visibleFacets = FACET_DEFS.filter(def => {
+        if (lockedFilters?.has(def.key)) {
+            return false;
+        }
+        const options = normalizeOptions(def.key, facets);
+        return options.length > 0;
+    });
+
+    if (visibleFacets.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mayo-event-filters" role="region" aria-label={__('Event filters', 'mayo-events-manager')}>
+            {visibleFacets.map(def => {
+                const options = normalizeOptions(def.key, facets);
+                const currentValue = selected?.[def.key] || '';
+                const selectId = `mayo-event-filter-${def.key}`;
+                return (
+                    <div key={def.key} className="mayo-event-filter">
+                        <label htmlFor={selectId} className="mayo-event-filter-label">
+                            {def.i18nLabel()}
+                        </label>
+                        <select
+                            id={selectId}
+                            className="mayo-event-filter-select"
+                            value={currentValue}
+                            onChange={(e) => onChange(def.key, e.target.value)}
+                        >
+                            <option value="">{__('All', 'mayo-events-manager')}</option>
+                            {options.map(option => (
+                                <option key={`${option.value}-${option.sourceId || ''}`} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                );
+            })}
+            {Object.values(selected || {}).some(v => v) && (
+                <button
+                    type="button"
+                    className="mayo-event-filter-clear"
+                    onClick={() => onChange('__clear__', '')}
+                >
+                    {__('Clear filters', 'mayo-events-manager')}
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default EventFilters;

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -1,10 +1,30 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 const FACET_DEFS = [
-    { key: 'event_type', i18nLabel: () => __('Event Type', 'mayo-events-manager') },
-    { key: 'service_body', i18nLabel: () => __('Service Body', 'mayo-events-manager') },
-    { key: 'categories', i18nLabel: () => __('Category', 'mayo-events-manager') },
-    { key: 'tags', i18nLabel: () => __('Tag', 'mayo-events-manager') },
+    {
+        key: 'event_type',
+        i18nLabel: () => __('Event Type', 'mayo-events-manager'),
+        /* translators: dropdown placeholder for the event-type filter */
+        i18nPlaceholder: () => __('Filter by event type…', 'mayo-events-manager'),
+    },
+    {
+        key: 'service_body',
+        i18nLabel: () => __('Service Body', 'mayo-events-manager'),
+        /* translators: dropdown placeholder for the service-body filter */
+        i18nPlaceholder: () => __('Filter by service body…', 'mayo-events-manager'),
+    },
+    {
+        key: 'categories',
+        i18nLabel: () => __('Category', 'mayo-events-manager'),
+        /* translators: dropdown placeholder for the category filter */
+        i18nPlaceholder: () => __('Filter by category…', 'mayo-events-manager'),
+    },
+    {
+        key: 'tags',
+        i18nLabel: () => __('Tag', 'mayo-events-manager'),
+        /* translators: dropdown placeholder for the tag filter */
+        i18nPlaceholder: () => __('Filter by tag…', 'mayo-events-manager'),
+    },
 ];
 
 const normalizeOptions = (key, facets) => {
@@ -15,7 +35,6 @@ const normalizeOptions = (key, facets) => {
         return (facets?.service_bodies || []).map(body => ({
             value: String(body.id),
             label: body.name,
-            sourceId: body.source_id,
         }));
     }
     if (key === 'categories') {
@@ -27,7 +46,7 @@ const normalizeOptions = (key, facets) => {
     return [];
 };
 
-const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) => {
+const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilters }) => {
     const visibleFacets = FACET_DEFS.filter(def => {
         if (lockedFilters?.has(def.key)) {
             return false;
@@ -46,22 +65,52 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) =>
             {visibleFacets.map(def => {
                 const options = normalizeOptions(def.key, facets);
                 const activeValues = Array.isArray(selected?.[def.key]) ? selected[def.key] : [];
+                const availableOptions = options.filter(opt => !activeValues.includes(opt.value));
+                const valueToLabel = new Map(options.map(opt => [opt.value, opt.label]));
+                const selectId = `mayo-event-filter-${def.key}`;
                 return (
                     <div key={def.key} className="mayo-event-filter-group">
-                        <div className="mayo-event-filter-label">{def.i18nLabel()}</div>
-                        <div className="mayo-event-filter-pills">
-                            {options.map(option => {
-                                const isActive = activeValues.includes(option.value);
-                                return (
-                                    <button
-                                        key={`${option.value}-${option.sourceId || ''}`}
-                                        type="button"
-                                        className="mayo-event-filter-pill"
-                                        aria-pressed={isActive}
-                                        onClick={() => onToggle(def.key, option.value)}
-                                    >
+                        <label htmlFor={selectId} className="mayo-event-filter-label">
+                            {def.i18nLabel()}
+                        </label>
+                        <div className="mayo-event-filter-controls">
+                            <select
+                                id={selectId}
+                                className="mayo-event-filter-add"
+                                value=""
+                                onChange={(e) => {
+                                    if (e.target.value) {
+                                        onAdd(def.key, e.target.value);
+                                        e.target.value = '';
+                                    }
+                                }}
+                                disabled={availableOptions.length === 0}
+                            >
+                                <option value="">{def.i18nPlaceholder()}</option>
+                                {availableOptions.map(option => (
+                                    <option key={option.value} value={option.value}>
                                         {option.label}
-                                    </button>
+                                    </option>
+                                ))}
+                            </select>
+                            {activeValues.map(value => {
+                                const label = valueToLabel.get(value) || value;
+                                return (
+                                    <span key={value} className="mayo-event-filter-chip">
+                                        <span className="mayo-event-filter-chip-label">{label}</span>
+                                        <button
+                                            type="button"
+                                            className="mayo-event-filter-chip-remove"
+                                            onClick={() => onRemove(def.key, value)}
+                                            aria-label={sprintf(
+                                                /* translators: %s: filter value being removed */
+                                                __('Remove filter %s', 'mayo-events-manager'),
+                                                label
+                                            )}
+                                        >
+                                            ×
+                                        </button>
+                                    </span>
                                 );
                             })}
                         </div>

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -1,24 +1,25 @@
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 const FACET_DEFS = [
     {
         key: 'event_type',
-        /* translators: dropdown title/placeholder for the event-type filter */
+        /* translators: filter pill label and panel title for the event-type filter */
         i18nLabel: () => __('Event Type', 'mayo-events-manager'),
     },
     {
         key: 'service_body',
-        /* translators: dropdown title/placeholder for the service-body filter */
+        /* translators: filter pill label and panel title for the service-body filter */
         i18nLabel: () => __('Service Body', 'mayo-events-manager'),
     },
     {
         key: 'categories',
-        /* translators: dropdown title/placeholder for the category filter */
+        /* translators: filter pill label and panel title for the category filter */
         i18nLabel: () => __('Category', 'mayo-events-manager'),
     },
     {
         key: 'tags',
-        /* translators: dropdown title/placeholder for the tag filter */
+        /* translators: filter pill label and panel title for the tag filter */
         i18nLabel: () => __('Tag', 'mayo-events-manager'),
     },
 ];
@@ -42,13 +43,40 @@ const normalizeOptions = (key, facets) => {
     return [];
 };
 
-const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilters }) => {
+const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) => {
+    const containerRef = useRef(null);
+    const [openFacet, setOpenFacet] = useState(null);
+
     const visibleFacets = FACET_DEFS.filter(def => {
         if (lockedFilters?.has(def.key)) {
             return false;
         }
         return normalizeOptions(def.key, facets).length > 0;
     });
+
+    // Close the open panel when clicking outside, pressing Escape, or when the
+    // visible facets change underneath us.
+    useEffect(() => {
+        if (!openFacet) {
+            return undefined;
+        }
+        const onMouseDown = (e) => {
+            if (containerRef.current && !containerRef.current.contains(e.target)) {
+                setOpenFacet(null);
+            }
+        };
+        const onKey = (e) => {
+            if (e.key === 'Escape') {
+                setOpenFacet(null);
+            }
+        };
+        document.addEventListener('mousedown', onMouseDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onMouseDown);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [openFacet]);
 
     if (visibleFacets.length === 0) {
         return null;
@@ -57,56 +85,84 @@ const EventFilters = ({ facets, selected, onAdd, onRemove, onClear, lockedFilter
     const hasAnySelection = Object.values(selected || {}).some(arr => Array.isArray(arr) && arr.length > 0);
 
     return (
-        <div className="mayo-event-filters" role="region" aria-label={__('Event filters', 'mayo-events-manager')}>
+        <div
+            className="mayo-event-filters"
+            role="region"
+            aria-label={__('Event filters', 'mayo-events-manager')}
+            ref={containerRef}
+        >
             {visibleFacets.map(def => {
                 const options = normalizeOptions(def.key, facets);
                 const activeValues = Array.isArray(selected?.[def.key]) ? selected[def.key] : [];
-                const availableOptions = options.filter(opt => !activeValues.includes(opt.value));
-                const valueToLabel = new Map(options.map(opt => [opt.value, opt.label]));
-                const selectId = `mayo-event-filter-${def.key}`;
+                const isOpen = openFacet === def.key;
+                const count = activeValues.length;
+                const label = def.i18nLabel();
+                const panelId = `mayo-event-filter-panel-${def.key}`;
                 return (
-                    <div key={def.key} className="mayo-event-filter-group">
-                        <select
-                            id={selectId}
-                            className="mayo-event-filter-add"
-                            aria-label={def.i18nLabel()}
-                            title={def.i18nLabel()}
-                            value=""
-                            onChange={(e) => {
-                                if (e.target.value) {
-                                    onAdd(def.key, e.target.value);
-                                    e.target.value = '';
-                                }
-                            }}
-                            disabled={availableOptions.length === 0}
+                    <div key={def.key} className="mayo-event-filter-pill-wrap">
+                        <button
+                            type="button"
+                            className={
+                                'mayo-event-filter-pill'
+                                + (isOpen ? ' is-open' : '')
+                                + (count > 0 ? ' has-selection' : '')
+                            }
+                            aria-haspopup="listbox"
+                            aria-expanded={isOpen}
+                            aria-controls={panelId}
+                            onClick={() => setOpenFacet(isOpen ? null : def.key)}
                         >
-                            <option value="">{def.i18nLabel()}</option>
-                            {availableOptions.map(option => (
-                                <option key={option.value} value={option.value}>
-                                    {option.label}
-                                </option>
-                            ))}
-                        </select>
-                        {activeValues.map(value => {
-                            const label = valueToLabel.get(value) || value;
-                            return (
-                                <span key={value} className="mayo-event-filter-chip">
-                                    <span className="mayo-event-filter-chip-label">{label}</span>
+                            <span className="mayo-event-filter-pill-label">{label}</span>
+                            {count > 0 && (
+                                <span className="mayo-event-filter-pill-count">{count}</span>
+                            )}
+                        </button>
+                        {isOpen && (
+                            <div
+                                id={panelId}
+                                className="mayo-event-filter-panel"
+                                role="listbox"
+                                aria-multiselectable="true"
+                                aria-label={label}
+                            >
+                                <div className="mayo-event-filter-panel-header">
+                                    <span className="mayo-event-filter-panel-title">{label}</span>
                                     <button
                                         type="button"
-                                        className="mayo-event-filter-chip-remove"
-                                        onClick={() => onRemove(def.key, value)}
+                                        className="mayo-event-filter-panel-close"
+                                        onClick={() => setOpenFacet(null)}
                                         aria-label={sprintf(
-                                            /* translators: %s: filter value being removed */
-                                            __('Remove filter %s', 'mayo-events-manager'),
+                                            /* translators: %s: filter facet name being closed */
+                                            __('Close %s filter', 'mayo-events-manager'),
                                             label
                                         )}
                                     >
                                         ×
                                     </button>
-                                </span>
-                            );
-                        })}
+                                </div>
+                                <ul className="mayo-event-filter-panel-options">
+                                    {options.map(option => {
+                                        const isActive = activeValues.includes(option.value);
+                                        return (
+                                            <li key={option.value}>
+                                                <button
+                                                    type="button"
+                                                    className={
+                                                        'mayo-event-filter-option'
+                                                        + (isActive ? ' is-active' : '')
+                                                    }
+                                                    role="option"
+                                                    aria-selected={isActive}
+                                                    onClick={() => onToggle(def.key, option.value)}
+                                                >
+                                                    {option.label}
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            </div>
+                        )}
                     </div>
                 );
             })}

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -1,10 +1,10 @@
 import { __ } from '@wordpress/i18n';
 
 const FACET_DEFS = [
-    { key: 'event_type', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Event Type', 'mayo-events-manager') },
-    { key: 'service_body', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Service Body', 'mayo-events-manager') },
-    { key: 'categories', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Category', 'mayo-events-manager') },
-    { key: 'tags', valueKey: 'value', labelKey: 'label', i18nLabel: () => __('Tag', 'mayo-events-manager') },
+    { key: 'event_type', i18nLabel: () => __('Event Type', 'mayo-events-manager') },
+    { key: 'service_body', i18nLabel: () => __('Service Body', 'mayo-events-manager') },
+    { key: 'categories', i18nLabel: () => __('Category', 'mayo-events-manager') },
+    { key: 'tags', i18nLabel: () => __('Tag', 'mayo-events-manager') },
 ];
 
 const normalizeOptions = (key, facets) => {
@@ -27,51 +27,52 @@ const normalizeOptions = (key, facets) => {
     return [];
 };
 
-const EventFilters = ({ facets, selected, onChange, lockedFilters }) => {
+const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) => {
     const visibleFacets = FACET_DEFS.filter(def => {
         if (lockedFilters?.has(def.key)) {
             return false;
         }
-        const options = normalizeOptions(def.key, facets);
-        return options.length > 0;
+        return normalizeOptions(def.key, facets).length > 0;
     });
 
     if (visibleFacets.length === 0) {
         return null;
     }
 
+    const hasAnySelection = Object.values(selected || {}).some(arr => Array.isArray(arr) && arr.length > 0);
+
     return (
         <div className="mayo-event-filters" role="region" aria-label={__('Event filters', 'mayo-events-manager')}>
             {visibleFacets.map(def => {
                 const options = normalizeOptions(def.key, facets);
-                const currentValue = selected?.[def.key] || '';
-                const selectId = `mayo-event-filter-${def.key}`;
+                const activeValues = Array.isArray(selected?.[def.key]) ? selected[def.key] : [];
                 return (
-                    <div key={def.key} className="mayo-event-filter">
-                        <label htmlFor={selectId} className="mayo-event-filter-label">
-                            {def.i18nLabel()}
-                        </label>
-                        <select
-                            id={selectId}
-                            className="mayo-event-filter-select"
-                            value={currentValue}
-                            onChange={(e) => onChange(def.key, e.target.value)}
-                        >
-                            <option value="">{__('All', 'mayo-events-manager')}</option>
-                            {options.map(option => (
-                                <option key={`${option.value}-${option.sourceId || ''}`} value={option.value}>
-                                    {option.label}
-                                </option>
-                            ))}
-                        </select>
+                    <div key={def.key} className="mayo-event-filter-group">
+                        <div className="mayo-event-filter-label">{def.i18nLabel()}</div>
+                        <div className="mayo-event-filter-pills">
+                            {options.map(option => {
+                                const isActive = activeValues.includes(option.value);
+                                return (
+                                    <button
+                                        key={`${option.value}-${option.sourceId || ''}`}
+                                        type="button"
+                                        className="mayo-event-filter-pill"
+                                        aria-pressed={isActive}
+                                        onClick={() => onToggle(def.key, option.value)}
+                                    >
+                                        {option.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
                     </div>
                 );
             })}
-            {Object.values(selected || {}).some(v => v) && (
+            {hasAnySelection && (
                 <button
                     type="button"
                     className="mayo-event-filter-clear"
-                    onClick={() => onChange('__clear__', '')}
+                    onClick={onClear}
                 >
                     {__('Clear filters', 'mayo-events-manager')}
                 </button>

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -1,11 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import EventCard from './cards/EventCard';
 import EventWidgetCard from './cards/EventWidgetCard';
 import CalendarView from './CalendarView';
+import EventFilters from './EventFilters';
 import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
 import { getUserTimezone } from '../../timezones';
+
+const EMPTY_FILTERS = { event_type: '', service_body: '', categories: '', tags: '' };
+const EMPTY_FACETS = { event_types: [], service_bodies: [], categories: [], tags: [] };
 
 const EventList = ({ widget = false, settings = {} }) => {
     const containerRef = useRef(null);
@@ -30,7 +34,20 @@ const EventList = ({ widget = false, settings = {} }) => {
     const [calendarDate, setCalendarDate] = useState(new Date()); // Current month for calendar view
     const [calendarEvents, setCalendarEvents] = useState([]); // Events for calendar view
     const [calendarLoading, setCalendarLoading] = useState(false);
+    const [activeFilters, setActiveFilters] = useState(EMPTY_FILTERS);
+    const [facets, setFacets] = useState(EMPTY_FACETS);
     const { updateExternalServiceBodies } = useEventProvider();
+
+    // Locked facets: those pinned by a shortcode attribute should not be
+    // shown as user-selectable dropdowns (they'd just collapse to one value).
+    const lockedFilters = useMemo(() => {
+        const locked = new Set();
+        if (settings?.eventType) locked.add('event_type');
+        if (settings?.serviceBody) locked.add('service_body');
+        if (settings?.categories) locked.add('categories');
+        if (settings?.tags) locked.add('tags');
+        return locked;
+    }, [settings?.eventType, settings?.serviceBody, settings?.categories, settings?.tags]);
 
     // Get user's current timezone
     const userTimezone = getUserTimezone();
@@ -45,8 +62,12 @@ const EventList = ({ widget = false, settings = {} }) => {
         setError(null);
         setHasMore(true);
         setTotalPages(1);
-        
-        fetchEvents(1);
+        setActiveFilters(EMPTY_FILTERS);
+
+        fetchEvents(1, EMPTY_FILTERS);
+        if (!widget) {
+            fetchFacets();
+        }
     }, [settings, widget]);
 
     // Check for autoexpand in querystring or settings
@@ -260,17 +281,30 @@ const EventList = ({ widget = false, settings = {} }) => {
         return [...validEvents, ...invalidEvents];
     };
 
+    // Resolve a filter value with precedence: querystring > runtimeFilters > settings.
+    // Locked filters always use the settings value (the shortcode pin) so a user
+    // can't widen scope past what the site admin allowed.
+    const resolveFilter = (key, qsKey, settingsKey, runtimeFilters) => {
+        const qs = getQueryStringValue(qsKey);
+        if (qs !== null) return qs;
+        if (!lockedFilters.has(key) && runtimeFilters && runtimeFilters[key]) {
+            return runtimeFilters[key];
+        }
+        return settings?.[settingsKey] || '';
+    };
+
     // Update fetchEvents to use processEvents
-    const fetchEvents = async (page = 1) => {
+    const fetchEvents = async (page = 1, filterOverrides = null) => {
         setLoading(true);
         try {
+            const filters = filterOverrides || activeFilters;
             let status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
-            let eventType = getQueryStringValue('event_type') !== null ? getQueryStringValue('event_type') : (settings?.eventType || '');
-            let serviceBody = getQueryStringValue('service_body') !== null ? getQueryStringValue('service_body') : (settings?.serviceBody || '');
+            let eventType = resolveFilter('event_type', 'event_type', 'eventType', filters);
+            let serviceBody = resolveFilter('service_body', 'service_body', 'serviceBody', filters);
             let relation = getQueryStringValue('relation') !== null ? getQueryStringValue('relation') : (settings?.relation || 'AND');
-            let categories = getQueryStringValue('categories') !== null ? getQueryStringValue('categories') : (settings?.categories || '');
+            let categories = resolveFilter('categories', 'categories', 'categories', filters);
             let categoryRelation = getQueryStringValue('category_relation') !== null ? getQueryStringValue('category_relation') : (settings?.categoryRelation || 'OR');
-            let tags = getQueryStringValue('tags') !== null ? getQueryStringValue('tags') : (settings?.tags || '');
+            let tags = resolveFilter('tags', 'tags', 'tags', filters);
             let sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
             let archive = getQueryStringValue('archive') !== null ? getQueryStringValue('archive') : (settings?.showArchived ? 'true' : 'false');
             let infiniteScroll = getQueryStringValue('infinite_scroll') !== null ? getQueryStringValue('infinite_scroll') === 'true' : (settings?.infiniteScroll ?? true);
@@ -342,16 +376,17 @@ const EventList = ({ widget = false, settings = {} }) => {
     };
 
     // Fetch events for calendar view by date range
-    const fetchCalendarEvents = async (year, month) => {
+    const fetchCalendarEvents = async (year, month, filterOverrides = null) => {
         setCalendarLoading(true);
         try {
+            const filters = filterOverrides || activeFilters;
             let status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
-            let eventType = getQueryStringValue('event_type') !== null ? getQueryStringValue('event_type') : (settings?.eventType || '');
-            let serviceBody = getQueryStringValue('service_body') !== null ? getQueryStringValue('service_body') : (settings?.serviceBody || '');
+            let eventType = resolveFilter('event_type', 'event_type', 'eventType', filters);
+            let serviceBody = resolveFilter('service_body', 'service_body', 'serviceBody', filters);
             let relation = getQueryStringValue('relation') !== null ? getQueryStringValue('relation') : (settings?.relation || 'AND');
-            let categories = getQueryStringValue('categories') !== null ? getQueryStringValue('categories') : (settings?.categories || '');
+            let categories = resolveFilter('categories', 'categories', 'categories', filters);
             let categoryRelation = getQueryStringValue('category_relation') !== null ? getQueryStringValue('category_relation') : (settings?.categoryRelation || 'OR');
-            let tags = getQueryStringValue('tags') !== null ? getQueryStringValue('tags') : (settings?.tags || '');
+            let tags = resolveFilter('tags', 'tags', 'tags', filters);
             let sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
             let order = getQueryStringValue('order') !== null ? getQueryStringValue('order') : (settings?.order || 'ASC');
 
@@ -410,6 +445,47 @@ const EventList = ({ widget = false, settings = {} }) => {
             fetchCalendarEvents(calendarDate.getFullYear(), calendarDate.getMonth());
         }
     }, [viewMode]);
+
+    // Build the facets request URL using the shortcode-locked scope only — we
+    // intentionally exclude runtime user selections so the dropdowns keep their
+    // full option set as the user narrows results.
+    const fetchFacets = async () => {
+        try {
+            const params = new URLSearchParams();
+            const status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
+            const sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
+            params.append('status', status);
+            if (settings?.eventType) params.append('event_type', settings.eventType);
+            if (settings?.serviceBody) params.append('service_body', settings.serviceBody);
+            if (settings?.categories) params.append('categories', settings.categories);
+            if (settings?.tags) params.append('tags', settings.tags);
+            if (sourceIds) params.append('source_ids', sourceIds);
+            params.append('timezone', userTimezone);
+
+            const data = await apiFetch(`/events/facets?${params.toString()}`);
+            setFacets({
+                event_types: Array.isArray(data?.event_types) ? data.event_types : [],
+                service_bodies: Array.isArray(data?.service_bodies) ? data.service_bodies : [],
+                categories: Array.isArray(data?.categories) ? data.categories : [],
+                tags: Array.isArray(data?.tags) ? data.tags : [],
+            });
+        } catch (err) {
+            console.error('Error in fetchFacets:', err);
+            setFacets(EMPTY_FACETS);
+        }
+    };
+
+    const handleFilterChange = (key, value) => {
+        const next = key === '__clear__' ? { ...EMPTY_FILTERS } : { ...activeFilters, [key]: value };
+        setActiveFilters(next);
+        setCurrentPage(1);
+        setEvents([]);
+        setHasMore(true);
+        fetchEvents(1, next);
+        if (viewMode === 'calendar' && !isWidget) {
+            fetchCalendarEvents(calendarDate.getFullYear(), calendarDate.getMonth(), next);
+        }
+    };
 
     const handlePrint = () => {
         // Create a new window for printing
@@ -534,19 +610,50 @@ const EventList = ({ widget = false, settings = {} }) => {
         };
     };
 
-    if (loading && events.length === 0) return <div>{__('Loading events...', 'mayo-events-manager')}</div>;
-    if (error && events.length === 0) return <div className="mayo-error">{error}</div>;
+    const hasActiveFilters = Object.values(activeFilters).some(v => v);
+
+    const renderFilters = () => (!isWidget ? (
+        <EventFilters
+            facets={facets}
+            selected={activeFilters}
+            onChange={handleFilterChange}
+            lockedFilters={lockedFilters}
+        />
+    ) : null);
+
+    if (loading && events.length === 0) {
+        return (
+            <div className="mayo-event-list" ref={containerRef}>
+                {renderFilters()}
+                <div>{__('Loading events...', 'mayo-events-manager')}</div>
+            </div>
+        );
+    }
+    if (error && events.length === 0) {
+        return (
+            <div className="mayo-event-list" ref={containerRef}>
+                {renderFilters()}
+                <div className="mayo-error">{error}</div>
+            </div>
+        );
+    }
     if (!events.length) {
-        if (settings?.showArchived) {
-            return <div className="mayo-no-events">{__('No events found in the archive.', 'mayo-events-manager')}</div>;
-        } else {
-            return <div className="mayo-no-events">
-                {__('No upcoming events found.', 'mayo-events-manager')}{' '}
-                <a href={`${window.location.pathname}?archive=true`} className="mayo-archive-link">
-                    {__('View past events', 'mayo-events-manager')}
-                </a>
-            </div>;
-        }
+        const emptyMessage = hasActiveFilters
+            ? <div className="mayo-no-events">{__('No events match the selected filters.', 'mayo-events-manager')}</div>
+            : (settings?.showArchived
+                ? <div className="mayo-no-events">{__('No events found in the archive.', 'mayo-events-manager')}</div>
+                : <div className="mayo-no-events">
+                    {__('No upcoming events found.', 'mayo-events-manager')}{' '}
+                    <a href={`${window.location.pathname}?archive=true`} className="mayo-archive-link">
+                        {__('View past events', 'mayo-events-manager')}
+                    </a>
+                </div>);
+        return (
+            <div className="mayo-event-list" ref={containerRef}>
+                {renderFilters()}
+                {emptyMessage}
+            </div>
+        );
     }
 
     return (
@@ -563,6 +670,7 @@ const EventList = ({ widget = false, settings = {} }) => {
                 </div>
             ) : (
                 <>
+                    {renderFilters()}
                     <div className="mayo-event-list-header">
                         <div className="mayo-view-toggle">
                             <button

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -15,7 +15,6 @@ const EventList = ({ widget = false, settings = {} }) => {
     const containerRef = useRef(null);
     const loaderRef = useRef(null);
     const updateTimeout = useRef(null);
-    const isInitialFilterEffect = useRef(true);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [events, setEvents] = useState([]);
@@ -53,20 +52,15 @@ const EventList = ({ widget = false, settings = {} }) => {
     // Get user's current timezone
     const userTimezone = getUserTimezone();
 
-    // Initialize component
+    // Initialize component. Reset to the shortcode-provided defaults; the
+    // activeFilters useEffect below picks up the EMPTY_FILTERS reset (or the
+    // initial mount) and is solely responsible for fetching events.
     useEffect(() => {
         setIsWidget(widget);
         setTimeFormat(settings?.timeFormat || '12hour');
-        setCurrentPage(1);
-        setEvents([]);
-        setLoading(true);
         setError(null);
-        setHasMore(true);
         setTotalPages(1);
         setActiveFilters(EMPTY_FILTERS);
-        isInitialFilterEffect.current = true;
-
-        fetchEvents(1);
         if (!widget) {
             fetchFacets();
         }
@@ -462,28 +456,34 @@ const EventList = ({ widget = false, settings = {} }) => {
         }
     };
 
-    const handleToggleFilter = (key, value) => {
+    const handleAddFilter = (key, value) => {
+        if (lockedFilters.has(key) || !value) {
+            return;
+        }
+        const current = Array.isArray(activeFilters[key]) ? activeFilters[key] : [];
+        if (current.includes(value)) {
+            return;
+        }
+        setActiveFilters({ ...activeFilters, [key]: [...current, value] });
+    };
+
+    const handleRemoveFilter = (key, value) => {
         if (lockedFilters.has(key)) {
             return;
         }
         const current = Array.isArray(activeFilters[key]) ? activeFilters[key] : [];
-        const next = current.includes(value)
-            ? current.filter(v => v !== value)
-            : [...current, value];
-        setActiveFilters({ ...activeFilters, [key]: next });
+        setActiveFilters({ ...activeFilters, [key]: current.filter(v => v !== value) });
     };
 
     const handleClearFilters = () => {
         setActiveFilters(EMPTY_FILTERS);
     };
 
-    // Refetch whenever the user changes a filter. The init useEffect handles the
-    // first load; this one fires only on subsequent activeFilters changes.
+    // Single source of truth for refetching: any change to activeFilters
+    // (including the EMPTY_FILTERS reset that the init effect performs)
+    // resets paging and re-fetches the list, plus the calendar if open.
     useEffect(() => {
-        if (isInitialFilterEffect.current) {
-            isInitialFilterEffect.current = false;
-            return;
-        }
+        setLoading(true);
         setCurrentPage(1);
         setEvents([]);
         setHasMore(true);
@@ -622,7 +622,8 @@ const EventList = ({ widget = false, settings = {} }) => {
         <EventFilters
             facets={facets}
             selected={activeFilters}
-            onToggle={handleToggleFilter}
+            onAdd={handleAddFilter}
+            onRemove={handleRemoveFilter}
             onClear={handleClearFilters}
             lockedFilters={lockedFilters}
         />

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -8,13 +8,14 @@ import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
 import { getUserTimezone } from '../../timezones';
 
-const EMPTY_FILTERS = { event_type: '', service_body: '', categories: '', tags: '' };
+const EMPTY_FILTERS = { event_type: [], service_body: [], categories: [], tags: [] };
 const EMPTY_FACETS = { event_types: [], service_bodies: [], categories: [], tags: [] };
 
 const EventList = ({ widget = false, settings = {} }) => {
     const containerRef = useRef(null);
     const loaderRef = useRef(null);
     const updateTimeout = useRef(null);
+    const isInitialFilterEffect = useRef(true);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [events, setEvents] = useState([]);
@@ -63,8 +64,9 @@ const EventList = ({ widget = false, settings = {} }) => {
         setHasMore(true);
         setTotalPages(1);
         setActiveFilters(EMPTY_FILTERS);
+        isInitialFilterEffect.current = true;
 
-        fetchEvents(1, EMPTY_FILTERS);
+        fetchEvents(1);
         if (!widget) {
             fetchFacets();
         }
@@ -281,53 +283,61 @@ const EventList = ({ widget = false, settings = {} }) => {
         return [...validEvents, ...invalidEvents];
     };
 
-    // Resolve a filter value with precedence: querystring > runtimeFilters > settings.
-    // Locked filters always use the settings value (the shortcode pin) so a user
-    // can't widen scope past what the site admin allowed.
-    const resolveFilter = (key, qsKey, settingsKey, runtimeFilters) => {
+    // Resolve a filter value with precedence: querystring > runtime selection > shortcode setting.
+    // Locked filters always use the settings value (the shortcode pin) so a user can't widen
+    // scope past what the site admin allowed. Runtime selection is an array (multi-select pills).
+    const resolveFilterValue = (key, qsKey, settingsKey) => {
         const qs = getQueryStringValue(qsKey);
         if (qs !== null) return qs;
-        if (!lockedFilters.has(key) && runtimeFilters && runtimeFilters[key]) {
-            return runtimeFilters[key];
+        if (lockedFilters.has(key)) {
+            return settings?.[settingsKey] || '';
+        }
+        const runtime = activeFilters[key];
+        if (Array.isArray(runtime) && runtime.length > 0) {
+            return runtime.join(',');
         }
         return settings?.[settingsKey] || '';
     };
 
+    const buildEventsQueryParams = (extra = {}) => {
+        const params = new URLSearchParams();
+        const status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
+        const relation = getQueryStringValue('relation') !== null ? getQueryStringValue('relation') : (settings?.relation || 'AND');
+        const categoryRelation = getQueryStringValue('category_relation') !== null ? getQueryStringValue('category_relation') : (settings?.categoryRelation || 'OR');
+        const sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
+        const archive = getQueryStringValue('archive') !== null ? getQueryStringValue('archive') : (settings?.showArchived ? 'true' : 'false');
+        const order = getQueryStringValue('order') !== null ? getQueryStringValue('order') : (settings?.order || 'ASC');
+
+        params.append('status', status);
+        params.append('event_type', resolveFilterValue('event_type', 'event_type', 'eventType'));
+        params.append('service_body', resolveFilterValue('service_body', 'service_body', 'serviceBody'));
+        params.append('relation', relation);
+        params.append('categories', resolveFilterValue('categories', 'categories', 'categories'));
+        params.append('category_relation', categoryRelation);
+        params.append('tags', resolveFilterValue('tags', 'tags', 'tags'));
+        params.append('source_ids', sourceIds);
+        params.append('timezone', userTimezone);
+        params.append('current_time', new Date().toISOString());
+        params.append('archive', archive);
+        params.append('order', order);
+
+        Object.entries(extra).forEach(([k, v]) => params.append(k, String(v)));
+        return params;
+    };
+
     // Update fetchEvents to use processEvents
-    const fetchEvents = async (page = 1, filterOverrides = null) => {
+    const fetchEvents = async (page = 1) => {
         setLoading(true);
         try {
-            const filters = filterOverrides || activeFilters;
-            let status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
-            let eventType = resolveFilter('event_type', 'event_type', 'eventType', filters);
-            let serviceBody = resolveFilter('service_body', 'service_body', 'serviceBody', filters);
-            let relation = getQueryStringValue('relation') !== null ? getQueryStringValue('relation') : (settings?.relation || 'AND');
-            let categories = resolveFilter('categories', 'categories', 'categories', filters);
-            let categoryRelation = getQueryStringValue('category_relation') !== null ? getQueryStringValue('category_relation') : (settings?.categoryRelation || 'OR');
-            let tags = resolveFilter('tags', 'tags', 'tags', filters);
-            let sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
-            let archive = getQueryStringValue('archive') !== null ? getQueryStringValue('archive') : (settings?.showArchived ? 'true' : 'false');
-            let infiniteScroll = getQueryStringValue('infinite_scroll') !== null ? getQueryStringValue('infinite_scroll') === 'true' : (settings?.infiniteScroll ?? true);
-            let perPage = getQueryStringValue('per_page') !== null ? parseInt(getQueryStringValue('per_page')) : (settings?.perPage || 10);
-            let order = getQueryStringValue('order') !== null ? getQueryStringValue('order') : (settings?.order || 'ASC');
+            const infiniteScroll = getQueryStringValue('infinite_scroll') !== null
+                ? getQueryStringValue('infinite_scroll') === 'true'
+                : (settings?.infiniteScroll ?? true);
+            const perPage = getQueryStringValue('per_page') !== null
+                ? parseInt(getQueryStringValue('per_page'))
+                : (settings?.perPage || 10);
 
-            // Build the endpoint URL with query parameters
-            const endpoint = `/events?status=${status}`
-                + `&event_type=${eventType}`
-                + `&service_body=${serviceBody}`
-                + `&relation=${relation}`
-                + `&categories=${categories}`
-                + `&category_relation=${categoryRelation}`
-                + `&tags=${tags}`
-                + `&source_ids=${sourceIds}`
-                + `&page=${page}`
-                + `&per_page=${perPage}`
-                + `&timezone=${encodeURIComponent(userTimezone)}`
-                + `&current_time=${encodeURIComponent(new Date().toISOString())}`
-                + `&archive=${archive}`
-                + `&order=${order}`;
-            
-            const data = await apiFetch(endpoint);
+            const params = buildEventsQueryParams({ page, per_page: perPage });
+            const data = await apiFetch(`/events?${params.toString()}`);
 
             // Handle both old and new response formats
             const events = Array.isArray(data) ? data : (data.events || []);
@@ -376,42 +386,19 @@ const EventList = ({ widget = false, settings = {} }) => {
     };
 
     // Fetch events for calendar view by date range
-    const fetchCalendarEvents = async (year, month, filterOverrides = null) => {
+    const fetchCalendarEvents = async (year, month) => {
         setCalendarLoading(true);
         try {
-            const filters = filterOverrides || activeFilters;
-            let status = getQueryStringValue('status') !== null ? getQueryStringValue('status') : (settings?.status || 'publish');
-            let eventType = resolveFilter('event_type', 'event_type', 'eventType', filters);
-            let serviceBody = resolveFilter('service_body', 'service_body', 'serviceBody', filters);
-            let relation = getQueryStringValue('relation') !== null ? getQueryStringValue('relation') : (settings?.relation || 'AND');
-            let categories = resolveFilter('categories', 'categories', 'categories', filters);
-            let categoryRelation = getQueryStringValue('category_relation') !== null ? getQueryStringValue('category_relation') : (settings?.categoryRelation || 'OR');
-            let tags = resolveFilter('tags', 'tags', 'tags', filters);
-            let sourceIds = getQueryStringValue('source_ids') !== null ? getQueryStringValue('source_ids') : (settings?.sourceIds || '');
-            let order = getQueryStringValue('order') !== null ? getQueryStringValue('order') : (settings?.order || 'ASC');
-
-            // Calculate start and end dates for the month
             const startDate = `${year}-${String(month + 1).padStart(2, '0')}-01`;
             const lastDay = new Date(year, month + 1, 0).getDate();
             const endDate = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
 
-            // Build the endpoint URL with date range parameters
-            const endpoint = `/events?status=${status}`
-                + `&event_type=${eventType}`
-                + `&service_body=${serviceBody}`
-                + `&relation=${relation}`
-                + `&categories=${categories}`
-                + `&category_relation=${categoryRelation}`
-                + `&tags=${tags}`
-                + `&source_ids=${sourceIds}`
-                + `&timezone=${encodeURIComponent(userTimezone)}`
-                + `&current_time=${encodeURIComponent(new Date().toISOString())}`
-                + `&order=${order}`
-                + `&start_date=${startDate}`
-                + `&end_date=${endDate}`
-                + `&per_page=100`; // Get all events for the month
-
-            const data = await apiFetch(endpoint);
+            const params = buildEventsQueryParams({
+                start_date: startDate,
+                end_date: endDate,
+                per_page: 100,
+            });
+            const data = await apiFetch(`/events?${params.toString()}`);
 
             // Handle both old and new response formats
             const fetchedEvents = Array.isArray(data) ? data : (data.events || []);
@@ -475,17 +462,36 @@ const EventList = ({ widget = false, settings = {} }) => {
         }
     };
 
-    const handleFilterChange = (key, value) => {
-        const next = key === '__clear__' ? { ...EMPTY_FILTERS } : { ...activeFilters, [key]: value };
-        setActiveFilters(next);
+    const handleToggleFilter = (key, value) => {
+        if (lockedFilters.has(key)) {
+            return;
+        }
+        const current = Array.isArray(activeFilters[key]) ? activeFilters[key] : [];
+        const next = current.includes(value)
+            ? current.filter(v => v !== value)
+            : [...current, value];
+        setActiveFilters({ ...activeFilters, [key]: next });
+    };
+
+    const handleClearFilters = () => {
+        setActiveFilters(EMPTY_FILTERS);
+    };
+
+    // Refetch whenever the user changes a filter. The init useEffect handles the
+    // first load; this one fires only on subsequent activeFilters changes.
+    useEffect(() => {
+        if (isInitialFilterEffect.current) {
+            isInitialFilterEffect.current = false;
+            return;
+        }
         setCurrentPage(1);
         setEvents([]);
         setHasMore(true);
-        fetchEvents(1, next);
+        fetchEvents(1);
         if (viewMode === 'calendar' && !isWidget) {
-            fetchCalendarEvents(calendarDate.getFullYear(), calendarDate.getMonth(), next);
+            fetchCalendarEvents(calendarDate.getFullYear(), calendarDate.getMonth());
         }
-    };
+    }, [activeFilters]);
 
     const handlePrint = () => {
         // Create a new window for printing
@@ -610,13 +616,14 @@ const EventList = ({ widget = false, settings = {} }) => {
         };
     };
 
-    const hasActiveFilters = Object.values(activeFilters).some(v => v);
+    const hasActiveFilters = Object.values(activeFilters).some(arr => Array.isArray(arr) && arr.length > 0);
 
     const renderFilters = () => (!isWidget ? (
         <EventFilters
             facets={facets}
             selected={activeFilters}
-            onChange={handleFilterChange}
+            onToggle={handleToggleFilter}
+            onClear={handleClearFilters}
             lockedFilters={lockedFilters}
         />
     ) : null);

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -456,23 +456,15 @@ const EventList = ({ widget = false, settings = {} }) => {
         }
     };
 
-    const handleAddFilter = (key, value) => {
+    const handleToggleFilter = (key, value) => {
         if (lockedFilters.has(key) || !value) {
             return;
         }
         const current = Array.isArray(activeFilters[key]) ? activeFilters[key] : [];
-        if (current.includes(value)) {
-            return;
-        }
-        setActiveFilters({ ...activeFilters, [key]: [...current, value] });
-    };
-
-    const handleRemoveFilter = (key, value) => {
-        if (lockedFilters.has(key)) {
-            return;
-        }
-        const current = Array.isArray(activeFilters[key]) ? activeFilters[key] : [];
-        setActiveFilters({ ...activeFilters, [key]: current.filter(v => v !== value) });
+        const next = current.includes(value)
+            ? current.filter(v => v !== value)
+            : [...current, value];
+        setActiveFilters({ ...activeFilters, [key]: next });
     };
 
     const handleClearFilters = () => {
@@ -622,8 +614,7 @@ const EventList = ({ widget = false, settings = {} }) => {
         <EventFilters
             facets={facets}
             selected={activeFilters}
-            onAdd={handleAddFilter}
-            onRemove={handleRemoveFilter}
+            onToggle={handleToggleFilter}
             onClear={handleClearFilters}
             lockedFilters={lockedFilters}
         />

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1352,19 +1352,7 @@ class EventsController {
             $source_map[$sid] = $source;
 
             // Events URL (same logic as fetch_external_events)
-            $params = [];
-            if (!empty($source['event_type'])) {
-                $params['event_type'] = $source['event_type'];
-            }
-            if (!empty($source['service_body'])) {
-                $params['service_body'] = $source['service_body'];
-            }
-            if (!empty($source['categories'])) {
-                $params['categories'] = $source['categories'];
-            }
-            if (!empty($source['tags'])) {
-                $params['tags'] = $source['tags'];
-            }
+            $params = self::build_external_filter_params($source);
             if (isset($_GET['archive'])) {
                 $params['archive'] = $_GET['archive'];
             }
@@ -1525,6 +1513,72 @@ class EventsController {
     }
 
     /**
+     * Merge an external source's admin-configured filter with the user's
+     * runtime $_GET filter for a single facet.
+     *
+     * Both inputs are comma-separated strings. When both are non-empty, the
+     * result is their intersection so an admin's pin cannot be widened by
+     * the visitor. When only one is set, that one wins. When the user's
+     * selection has no overlap with the admin pin, the admin pin is kept
+     * (avoid widening scope).
+     *
+     * @param string $source_value Admin-configured value (may be empty)
+     * @param string $user_value   $_GET-provided value (may be empty)
+     * @return string Combined filter value (empty if neither set)
+     */
+    private static function merge_filter_value($source_value, $user_value) {
+        $source_value = is_string($source_value) ? trim($source_value) : '';
+        $user_value = is_string($user_value) ? trim($user_value) : '';
+
+        if ($source_value === '') {
+            return $user_value;
+        }
+        if ($user_value === '') {
+            return $source_value;
+        }
+
+        $source_list = array_filter(array_map('trim', explode(',', $source_value)), function ($v) {
+            return $v !== '';
+        });
+        $user_list = array_filter(array_map('trim', explode(',', $user_value)), function ($v) {
+            return $v !== '';
+        });
+        $intersection = array_values(array_intersect($source_list, $user_list));
+        if (!empty($intersection)) {
+            return implode(',', $intersection);
+        }
+        return $source_value;
+    }
+
+    /**
+     * Build the filter params (event_type, service_body, categories, tags) for
+     * an external feed request by merging the source's admin pin with the
+     * current visitor's $_GET selection.
+     *
+     * @param array $source Source configuration entry
+     * @return array Associative array of filter params (only set keys are returned)
+     */
+    private static function build_external_filter_params($source) {
+        $get_param = function ($key) {
+            return isset($_GET[$key]) ? sanitize_text_field(wp_unslash($_GET[$key])) : '';
+        };
+        $merged = [
+            'event_type' => self::merge_filter_value($source['event_type'] ?? '', $get_param('event_type')),
+            'service_body' => self::merge_filter_value($source['service_body'] ?? '', $get_param('service_body')),
+            'categories' => self::merge_filter_value($source['categories'] ?? '', $get_param('categories')),
+            'tags' => self::merge_filter_value($source['tags'] ?? '', $get_param('tags')),
+        ];
+
+        $params = [];
+        foreach ($merged as $key => $value) {
+            if ($value !== '') {
+                $params[$key] = $value;
+            }
+        }
+        return $params;
+    }
+
+    /**
      * Fetch events from external source
      *
      * @param array $source External source configuration
@@ -1533,11 +1587,7 @@ class EventsController {
     private static function fetch_external_events($source, $include_debug = false) {
         $debug = ['calls' => []];
         try {
-            $params = [];
-            if (!empty($source['event_type'])) $params['event_type'] = $source['event_type'];
-            if (!empty($source['service_body'])) $params['service_body'] = $source['service_body'];
-            if (!empty($source['categories'])) $params['categories'] = $source['categories'];
-            if (!empty($source['tags'])) $params['tags'] = $source['tags'];
+            $params = self::build_external_filter_params($source);
 
             if (isset($_GET['archive'])) $params['archive'] = $_GET['archive'];
             if (isset($_GET['timezone'])) $params['timezone'] = $_GET['timezone'];

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -36,6 +36,12 @@ class EventsController {
             'permission_callback' => '__return_true',
         ]);
 
+        register_rest_route('event-manager/v1', '/events/facets', [
+            'methods' => 'GET',
+            'callback' => [__CLASS__, 'get_events_facets'],
+            'permission_callback' => '__return_true',
+        ]);
+
         register_rest_route('event-manager/v1', '/event/(?P<slug>[a-zA-Z0-9-]+)', [
             'methods' => 'GET',
             'callback' => [__CLASS__, 'get_event_details'],
@@ -315,6 +321,184 @@ class EventsController {
         }
 
         return new \WP_REST_Response($response_data);
+    }
+
+    /**
+     * Get distinct filter facet values across the full (unpaginated) result set.
+     *
+     * Accepts the same scope parameters as get_events (event_type, service_body,
+     * categories, tags, source_ids, status, date range). Returns distinct values
+     * for the four display filters so the frontend filter bar can populate its
+     * dropdowns from the actual data — including service bodies surfaced by
+     * external feeds.
+     *
+     * @return \WP_REST_Response
+     */
+    public static function get_events_facets() {
+        $previous_error_reporting = error_reporting();
+        error_reporting(E_ERROR | E_PARSE);
+
+        $events = [];
+        $sources = [];
+
+        $sourceIds = isset($_GET['source_ids']) ?
+            array_map('trim', array_filter(explode(',', sanitize_text_field(wp_unslash($_GET['source_ids']))))) :
+            [];
+
+        if (empty($sourceIds) || in_array('local', $sourceIds)) {
+            $local_events = self::get_local_events($_GET);
+            $sources['local'] = [
+                'id' => 'local',
+                'name' => 'Local Events',
+                'url' => get_site_url(),
+                'service_bodies' => self::get_local_service_bodies(),
+            ];
+            $events = array_merge($events, array_map(function ($event) {
+                $event['source_id'] = 'local';
+                return $event;
+            }, $local_events));
+        }
+
+        if (!empty($sourceIds)) {
+            $external_sources = get_option('mayo_external_sources', []);
+            $enabled_sources = [];
+            foreach ($external_sources as $source) {
+                if (in_array($source['id'], $sourceIds) && !empty($source['enabled'])) {
+                    $enabled_sources[] = $source;
+                }
+            }
+            if (!empty($enabled_sources)) {
+                $external_result = self::fetch_all_external_events($enabled_sources, false);
+                $events = array_merge($events, $external_result['events']);
+                foreach ($external_result['sources'] as $id => $source_info) {
+                    $sources[$id] = $source_info;
+                }
+            }
+        }
+
+        $event_types = [];
+        $service_bodies = [];
+        $service_body_seen = [];
+        $categories = [];
+        $category_seen = [];
+        $tags = [];
+        $tag_seen = [];
+
+        foreach ($events as $event) {
+            $type = isset($event['meta']['event_type']) ? trim((string) $event['meta']['event_type']) : '';
+            if ($type !== '' && !in_array($type, $event_types, true)) {
+                $event_types[] = $type;
+            }
+
+            $service_body_id = isset($event['meta']['service_body']) ? trim((string) $event['meta']['service_body']) : '';
+            if ($service_body_id !== '') {
+                $source_id = isset($event['source_id']) ? (string) $event['source_id'] : 'local';
+                $key = $source_id . ':' . $service_body_id;
+                if (!isset($service_body_seen[$key])) {
+                    $service_body_seen[$key] = true;
+                    $service_bodies[] = [
+                        'id' => $service_body_id,
+                        'name' => self::resolve_service_body_name($service_body_id, $source_id, $sources),
+                        'source_id' => $source_id,
+                    ];
+                }
+            }
+
+            if (!empty($event['categories']) && is_array($event['categories'])) {
+                foreach ($event['categories'] as $term) {
+                    $slug = isset($term['slug']) ? (string) $term['slug'] : '';
+                    if ($slug === '' || isset($category_seen[$slug])) {
+                        continue;
+                    }
+                    $category_seen[$slug] = true;
+                    $categories[] = [
+                        'slug' => $slug,
+                        'name' => html_entity_decode(isset($term['name']) ? (string) $term['name'] : $slug, ENT_QUOTES, 'UTF-8'),
+                    ];
+                }
+            }
+
+            if (!empty($event['tags']) && is_array($event['tags'])) {
+                foreach ($event['tags'] as $term) {
+                    $slug = isset($term['slug']) ? (string) $term['slug'] : '';
+                    if ($slug === '' || isset($tag_seen[$slug])) {
+                        continue;
+                    }
+                    $tag_seen[$slug] = true;
+                    $tags[] = [
+                        'slug' => $slug,
+                        'name' => html_entity_decode(isset($term['name']) ? (string) $term['name'] : $slug, ENT_QUOTES, 'UTF-8'),
+                    ];
+                }
+            }
+        }
+
+        sort($event_types);
+        usort($service_bodies, function ($a, $b) {
+            return strcasecmp($a['name'], $b['name']);
+        });
+        usort($categories, function ($a, $b) {
+            return strcasecmp($a['name'], $b['name']);
+        });
+        usort($tags, function ($a, $b) {
+            return strcasecmp($a['name'], $b['name']);
+        });
+
+        error_reporting($previous_error_reporting);
+
+        return new \WP_REST_Response([
+            'event_types' => $event_types,
+            'service_bodies' => $service_bodies,
+            'categories' => $categories,
+            'tags' => $tags,
+        ]);
+    }
+
+    /**
+     * Look up the human-readable name for a service body, given its source.
+     *
+     * Local service bodies come from the configured BMLT root server; external
+     * ones come from the per-source service_bodies array populated by
+     * fetch_all_external_events().
+     *
+     * @param string $id Service body ID
+     * @param string $source_id Source ID ('local' or external source id)
+     * @param array  $sources Sources array keyed by source id
+     * @return string Resolved name (defaults to the ID when not found)
+     */
+    private static function resolve_service_body_name($id, $source_id, $sources) {
+        if (isset($sources[$source_id]['service_bodies']) && is_array($sources[$source_id]['service_bodies'])) {
+            foreach ($sources[$source_id]['service_bodies'] as $body) {
+                if (isset($body['id']) && (string) $body['id'] === (string) $id) {
+                    return html_entity_decode((string) ($body['name'] ?? $id), ENT_QUOTES, 'UTF-8');
+                }
+            }
+        }
+        return (string) $id;
+    }
+
+    /**
+     * Fetch local service bodies from the configured BMLT root server.
+     *
+     * Mirrors the per-source service body list that external sources publish so
+     * the facets endpoint can resolve local service body IDs to names.
+     *
+     * @return array
+     */
+    private static function get_local_service_bodies() {
+        $settings = get_option('mayo_settings', []);
+        $root = isset($settings['bmlt_root_server']) ? trim((string) $settings['bmlt_root_server']) : '';
+        if ($root === '') {
+            return [];
+        }
+        $url = rtrim($root, '/') . '/client_interface/json/?switcher=GetServiceBodies';
+        $response = wp_remote_get($url, ['timeout' => 5]);
+        if (is_wp_error($response)) {
+            return [];
+        }
+        $body = wp_remote_retrieve_body($response);
+        $decoded = json_decode($body, true);
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/languages/mayo-events-manager.pot
+++ b/languages/mayo-events-manager.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Mayo Events Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/bmlt-enabled/mayo/issues\n"
-"POT-Creation-Date: 2026-05-17 18:17+0000\n"
+"POT-Creation-Date: 2026-05-17 18:24+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -292,11 +292,11 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:721
+#: assets/js/src/components/public/EventList.js:712
 msgid "Calendar Feed (ICS)"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:694
+#: assets/js/src/components/public/EventList.js:685
 msgid "Calendar View"
 msgstr ""
 
@@ -335,7 +335,7 @@ msgstr ""
 msgid "Categories: %s"
 msgstr ""
 
-#: assets/js/src/components/public/EventFilters.js:17
+#: assets/js/src/components/public/EventFilters.js:18
 msgid "Category"
 msgstr ""
 
@@ -350,8 +350,8 @@ msgstr ""
 msgid "Clear Upload"
 msgstr ""
 
-#: assets/js/src/components/public/EventFilters.js:118
-#: assets/js/src/components/public/EventFilters.js:119
+#: assets/js/src/components/public/EventFilters.js:174
+#: assets/js/src/components/public/EventFilters.js:175
 msgid "Clear filters"
 msgstr ""
 
@@ -370,7 +370,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:704
+#: assets/js/src/components/public/EventFilters.js:136
+msgid "Close %s filter"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:695
 msgid "Collapse All"
 msgstr ""
 
@@ -420,7 +424,7 @@ msgid "Control when this announcement is visible on the site."
 msgstr ""
 
 #: includes/Admin.php:602
-#: assets/js/src/components/public/EventList.js:753
+#: assets/js/src/components/public/EventList.js:744
 msgid "Copy"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Copy ID to clipboard"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:750
+#: assets/js/src/components/public/EventList.js:741
 msgid "Copy to Clipboard"
 msgstr ""
 
@@ -472,7 +476,7 @@ msgid "Date to skip"
 msgstr ""
 
 #: includes/Subscriber.php:900
-#: assets/js/src/components/public/EventList.js:584
+#: assets/js/src/components/public/EventList.js:576
 msgid "Date:"
 msgstr ""
 
@@ -725,7 +729,7 @@ msgstr ""
 #: assets/js/src/components/admin/Settings.js:522
 #: assets/js/src/components/public/EventForm.js:513
 #: assets/js/src/components/public/cards/EventCard.js:159
-#: assets/js/src/components/public/EventFilters.js:7
+#: assets/js/src/components/public/EventFilters.js:8
 #: assets/js/src/components/public/EventDetails.js:168
 msgid "Event Type"
 msgstr ""
@@ -746,7 +750,7 @@ msgstr ""
 msgid "Event details unavailable from %s"
 msgstr ""
 
-#: assets/js/src/components/public/EventFilters.js:60
+#: assets/js/src/components/public/EventFilters.js:91
 msgid "Event filters"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgstr ""
 msgid "Events will show as announcements when today's date is between the event's start and end dates."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:704
+#: assets/js/src/components/public/EventList.js:695
 msgid "Expand All"
 msgstr ""
 
@@ -922,7 +926,7 @@ msgstr ""
 msgid "Go to Today"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:737
+#: assets/js/src/components/public/EventList.js:728
 msgid "Hide Shortcode"
 msgstr ""
 
@@ -1049,7 +1053,7 @@ msgstr ""
 msgid "Links & Events"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:687
+#: assets/js/src/components/public/EventList.js:678
 msgid "List View"
 msgstr ""
 
@@ -1067,13 +1071,13 @@ msgstr ""
 
 #: assets/js/src/components/admin/AnnouncementEditor.js:208
 #: assets/js/src/components/public/CalendarView.js:339
-#: assets/js/src/components/public/EventList.js:636
+#: assets/js/src/components/public/EventList.js:627
 #: assets/js/src/components/public/EventArchive.js:45
 msgid "Loading events..."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:783
-#: assets/js/src/components/public/EventList.js:788
+#: assets/js/src/components/public/EventList.js:774
+#: assets/js/src/components/public/EventList.js:779
 msgid "Loading more events..."
 msgstr ""
 
@@ -1117,7 +1121,7 @@ msgstr ""
 
 #: includes/Subscriber.php:917
 #: includes/Rest/EventsController.php:914
-#: assets/js/src/components/public/EventList.js:586
+#: assets/js/src/components/public/EventList.js:578
 msgid "Location:"
 msgstr ""
 
@@ -1255,11 +1259,11 @@ msgstr ""
 msgid "No events found"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:652
+#: assets/js/src/components/public/EventList.js:643
 msgid "No events found in the archive."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:650
+#: assets/js/src/components/public/EventList.js:641
 msgid "No events match the selected filters."
 msgstr ""
 
@@ -1280,7 +1284,7 @@ msgstr ""
 msgid "No subscription options configured. Configure them in the Settings page."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:654
+#: assets/js/src/components/public/EventList.js:645
 msgid "No upcoming events found."
 msgstr ""
 
@@ -1428,11 +1432,11 @@ msgstr ""
 msgid "Previous Month"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:712
+#: assets/js/src/components/public/EventList.js:703
 msgid "Print Events"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:578
+#: assets/js/src/components/public/EventList.js:570
 msgid "Printed on"
 msgstr ""
 
@@ -1452,7 +1456,7 @@ msgid_plural "RELATED EVENTS"
 msgstr[0] ""
 msgstr[1] ""
 
-#: assets/js/src/components/public/EventList.js:730
+#: assets/js/src/components/public/EventList.js:721
 msgid "RSS Feed"
 msgstr ""
 
@@ -1497,10 +1501,6 @@ msgstr ""
 #: assets/js/src/components/admin/EventBlockEditorSidebar.js:380
 #: assets/js/src/components/admin/AnnouncementEditor.js:1133
 msgid "Remove"
-msgstr ""
-
-#: assets/js/src/components/public/EventFilters.js:101
-msgid "Remove filter %s"
 msgstr ""
 
 #: assets/js/src/components/admin/EventBlockEditorSidebar.js:244
@@ -1653,7 +1653,7 @@ msgstr ""
 #: assets/js/src/components/public/EventForm.js:531
 #: assets/js/src/components/public/cards/EventCard.js:212
 #: assets/js/src/components/public/AnnouncementForm.js:451
-#: assets/js/src/components/public/EventFilters.js:12
+#: assets/js/src/components/public/EventFilters.js:13
 #: assets/js/src/components/public/EventDetails.js:175
 #: assets/js/src/components/public/AnnouncementDetails.js:191
 msgid "Service Body"
@@ -1689,7 +1689,7 @@ msgstr ""
 msgid "Settings saved successfully!"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:746
+#: assets/js/src/components/public/EventList.js:737
 msgid "Shortcode for this event list:"
 msgstr ""
 
@@ -1699,7 +1699,7 @@ msgstr ""
 msgid "Shortcodes"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:737
+#: assets/js/src/components/public/EventList.js:728
 msgid "Show Shortcode"
 msgstr ""
 
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: assets/js/src/components/public/EventFilters.js:22
+#: assets/js/src/components/public/EventFilters.js:23
 msgid "Tag"
 msgstr ""
 
@@ -1991,7 +1991,7 @@ msgid "Type"
 msgstr ""
 
 #: assets/js/src/components/admin/Settings.js:468
-#: assets/js/src/components/public/EventList.js:585
+#: assets/js/src/components/public/EventList.js:577
 #: assets/js/src/components/public/EventArchive.js:77
 msgid "Type:"
 msgstr ""
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "View online:"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:656
+#: assets/js/src/components/public/EventList.js:647
 msgid "View past events"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgstr ""
 
 #: assets/js/src/components/public/cards/EventCard.js:147
 #: assets/js/src/components/public/cards/EventCard.js:152
-#: assets/js/src/components/public/EventList.js:584
+#: assets/js/src/components/public/EventList.js:576
 #: assets/js/src/components/public/EventDetails.js:183
 #: assets/js/src/components/public/EventDetails.js:188
 #: assets/js/src/components/public/AnnouncementDetails.js:98

--- a/languages/mayo-events-manager.pot
+++ b/languages/mayo-events-manager.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Mayo Events Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/bmlt-enabled/mayo/issues\n"
-"POT-Creation-Date: 2026-05-09 04:23+0000\n"
+"POT-Creation-Date: 2026-05-17 18:17+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -21,21 +21,26 @@ msgstr[1] ""
 msgid "%s (Copy)"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:605
 #: assets/js/src/components/public/EventForm.js:848
+#: assets/js/src/components/public/AnnouncementForm.js:605
 msgid "(Required)"
 msgstr ""
 
-#: includes/Rest/EventsController.php:678
+#: includes/Rest/EventsController.php:862
 msgid "(every %d days)"
 msgstr ""
 
-#: includes/Rest/EventsController.php:708
+#: includes/Rest/EventsController.php:892
 msgid "(every %d months)"
 msgstr ""
 
-#: includes/Rest/EventsController.php:685
+#: includes/Rest/EventsController.php:869
 msgid "(every %d weeks)"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:233
+#: assets/js/src/components/admin/AnnouncementEditor.js:918
+msgid "-- No timezone set --"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:127
@@ -61,16 +66,31 @@ msgid "API"
 msgstr ""
 
 #: includes/Admin.php:113
+#: assets/js/src/components/admin/ApiDocs.js:8
 msgid "API Documentation"
 msgstr ""
 
 #: includes/Announcement.php:300
 #: includes/Announcement.php:389
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:536
+#: assets/js/src/components/admin/Subscribers.js:65
+#: assets/js/src/components/admin/Subscribers.js:346
 msgid "Active"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:183
+#: assets/js/src/components/admin/Settings.js:526
 #: assets/js/src/components/public/EventForm.js:524
 msgid "Activity"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:381
+#: assets/js/src/components/admin/AnnouncementEditor.js:1150
+msgid "Add Custom Link"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:470
+msgid "Add Link"
 msgstr ""
 
 #: includes/Announcement.php:36
@@ -83,16 +103,46 @@ msgstr ""
 msgid "Add New Event"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:501
+msgid "Add New External Source"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:404
+msgid "Add Skip"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:424
+msgid "Add Skipped Date"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:989
+msgid "Add custom links or link to events. Custom links appear first."
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:908
 msgid "Additional details about the location (e.g., parking, entrance info)"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:461
 #: assets/js/src/components/public/EventForm.js:891
 msgid "Address"
 msgstr ""
 
-#: includes/Rest/EventsController.php:735
+#: includes/Rest/EventsController.php:919
 msgid "Address:"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:337
+#: assets/js/src/components/admin/Settings.js:468
+msgid "All"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:525
+msgid "All Event Types"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:461
+msgid "All announcements"
 msgstr ""
 
 #: includes/Admin.php:826
@@ -107,8 +157,8 @@ msgstr ""
 msgid "Always visible"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:688
 #: assets/js/src/components/public/EventForm.js:964
+#: assets/js/src/components/public/AnnouncementForm.js:688
 msgid "An error occurred while submitting the form. Please try again."
 msgstr ""
 
@@ -120,6 +170,22 @@ msgstr ""
 
 #: includes/Announcement.php:35
 msgid "Announcement"
+msgstr ""
+
+#: assets/js/src/components/admin/ApiDocs.js:844
+msgid "Announcement Response Object"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:843
+msgid "Announcement Settings"
+msgstr ""
+
+#: assets/js/src/components/admin/ShortcodesDocs.js:265
+msgid "Announcement Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/ShortcodesDocs.js:434
+msgid "Announcement Submission Form Shortcode"
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementForm.js:437
@@ -145,6 +211,10 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:516
+msgid "Announcements that reference this event."
+msgstr ""
+
 #: assets/js/src/util.js:16
 msgid "Apr"
 msgstr ""
@@ -157,6 +227,10 @@ msgstr ""
 msgid "Are you sure you want to copy this event?"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:255
+msgid "Are you sure you want to delete this external source?"
+msgstr ""
+
 #: includes/Widgets/AnnouncementWidget.php:193
 msgid "Ascending"
 msgstr ""
@@ -165,7 +239,7 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: includes/Rest/EventsController.php:757
+#: includes/Rest/EventsController.php:941
 msgid "Attachments:"
 msgstr ""
 
@@ -177,6 +251,22 @@ msgstr ""
 msgid "August"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:650
+msgid "Auto-include: Automatically add to existing subscribers"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:385
+msgid "BMLT Root Server URL"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:310
+msgid "BMLT Root Server URL must use HTTPS protocol."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:382
+msgid "BMLT Settings"
+msgstr ""
+
 #: includes/Widgets/AnnouncementWidget.php:136
 msgid "Background Color (hex):"
 msgstr ""
@@ -185,28 +275,46 @@ msgstr ""
 msgid "Banner (sticky top)"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:1219
+msgid "Based on selected categories, tags, and service body."
+msgstr ""
+
 #: includes/Admin.php:104
 #: includes/Admin.php:105
 msgid "CSS Classes"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:605
+#: assets/js/src/components/admin/CssClassesDocs.js:33
+msgid "CSS Classes Documentation"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:326
+msgid "Calendar"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:721
 msgid "Calendar Feed (ICS)"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:578
+#: assets/js/src/components/public/EventList.js:694
 msgid "Calendar View"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:414
+#: assets/js/src/components/admin/AnnouncementEditor.js:463
+#: assets/js/src/components/admin/Subscribers.js:129
+#: assets/js/src/components/admin/Settings.js:578
 #: mayo-events-manager.php:791
 msgid "Cancel"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:634
+#: assets/js/src/components/admin/Subscribers.js:80
+#: assets/js/src/components/admin/Settings.js:544
 #: assets/js/src/components/public/EventForm.js:913
+#: assets/js/src/components/public/AnnouncementForm.js:634
+#: assets/js/src/components/public/SubscribeForm.js:162
 #: assets/js/src/components/public/EventDetails.js:203
 #: assets/js/src/components/public/AnnouncementDetails.js:212
-#: assets/js/src/components/public/SubscribeForm.js:162
 #: mayo-events-manager.php:685
 msgid "Categories"
 msgstr ""
@@ -215,7 +323,11 @@ msgstr ""
 msgid "Categories (comma-separated slugs):"
 msgstr ""
 
-#: includes/Rest/EventsController.php:745
+#: assets/js/src/components/admin/Settings.js:594
+msgid "Categories available for subscription:"
+msgstr ""
+
+#: includes/Rest/EventsController.php:929
 msgid "Categories:"
 msgstr ""
 
@@ -223,38 +335,84 @@ msgstr ""
 msgid "Categories: %s"
 msgstr ""
 
+#: assets/js/src/components/public/EventFilters.js:17
+msgid "Category"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:184
+#: assets/js/src/components/admin/Settings.js:528
 #: assets/js/src/components/public/EventForm.js:525
 msgid "Celebration"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:624
 #: assets/js/src/components/public/EventForm.js:872
+#: assets/js/src/components/public/AnnouncementForm.js:624
 msgid "Clear Upload"
+msgstr ""
+
+#: assets/js/src/components/public/EventFilters.js:118
+#: assets/js/src/components/public/EventFilters.js:119
+msgid "Clear filters"
 msgstr ""
 
 #: includes/Subscriber.php:647
 msgid "Click the link below to confirm your subscription:"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:1220
+msgid "Click to view recipients."
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:314
+#: assets/js/src/components/admin/AnnouncementEditor.js:1316
 #: assets/js/src/components/public/EventModal.js:51
 #: assets/js/src/components/public/AnnouncementModal.js:79
 msgid "Close"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:588
+#: assets/js/src/components/public/EventList.js:704
 msgid "Collapse All"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:428
+msgid "Comma-separated list of service body IDs (e.g., 1,2,3). When specified, only these service bodies will be available for event submission. Leave empty to allow all service bodies."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:589
+msgid "Configure which categories, tags, and service bodies are available for subscribers to choose from when signing up for announcement notifications."
 msgstr ""
 
 #: mayo-events-manager.php:222
 msgid "Confirmation Error"
 msgstr ""
 
-#: includes/Rest/EventsController.php:783
+#: assets/js/src/components/admin/Subscribers.js:391
+#: assets/js/src/components/admin/Subscribers.js:475
+msgid "Confirmed"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:497
+msgid "Contact Email"
+msgstr ""
+
+#: includes/Rest/EventsController.php:967
 msgid "Contact Email: %s"
 msgstr ""
 
-#: includes/Rest/EventsController.php:781
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:485
+msgid "Contact Information (Private)"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:489
+msgid "Contact Name"
+msgstr ""
+
+#: includes/Rest/EventsController.php:965
 msgid "Contact Name: %s"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:848
+msgid "Control when this announcement is visible on the frontend."
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementForm.js:501
@@ -262,12 +420,24 @@ msgid "Control when this announcement is visible on the site."
 msgstr ""
 
 #: includes/Admin.php:602
-#: assets/js/src/components/public/EventList.js:637
+#: assets/js/src/components/public/EventList.js:753
 msgid "Copy"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:634
+#: assets/js/src/components/admin/Settings.js:462
+msgid "Copy ID"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:464
+msgid "Copy ID to clipboard"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:750
 msgid "Copy to Clipboard"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:600
+msgid "Create Announcement"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:176
@@ -275,28 +445,43 @@ msgid "Created Date"
 msgstr ""
 
 #: includes/Announcement.php:857
+#: assets/js/src/components/admin/AnnouncementEditor.js:1065
 msgid "Custom Link"
 msgstr ""
 
-#: includes/Rest/EventsController.php:675
+#: includes/Rest/EventsController.php:859
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:248
 #: assets/js/src/components/public/EventForm.js:667
 msgid "Daily"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:861
+#: assets/js/src/components/admin/AnnouncementEditor.js:892
+msgid "Date"
+msgstr ""
+
 #: includes/Admin.php:221
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:191
+#: assets/js/src/components/public/cards/EventCard.js:145
 #: assets/js/src/components/public/EventDetails.js:181
 msgid "Date & Time"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:391
+msgid "Date to skip"
+msgstr ""
+
 #: includes/Subscriber.php:900
-#: assets/js/src/components/public/EventList.js:502
+#: assets/js/src/components/public/EventList.js:584
 msgid "Date:"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:344
 #: assets/js/src/components/public/EventForm.js:779
 msgid "Day"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:320
 #: assets/js/src/components/public/EventForm.js:747
 msgid "Day of month"
 msgstr ""
@@ -313,24 +498,34 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:424
+#: assets/js/src/components/admin/Settings.js:487
+msgid "Delete"
+msgstr ""
+
 #: includes/Widgets/AnnouncementWidget.php:196
 msgid "Descending"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:571
 #: assets/js/src/components/public/EventForm.js:816
+#: assets/js/src/components/public/cards/EventCard.js:166
+#: assets/js/src/components/public/AnnouncementForm.js:571
 #: assets/js/src/components/public/EventDetails.js:144
 msgid "Description"
 msgstr ""
 
-#: includes/Rest/EventsController.php:792
+#: includes/Rest/EventsController.php:976
 #: includes/Rest/AnnouncementsController.php:386
 msgid "Description:"
 msgstr ""
 
-#: includes/Rest/EventsController.php:738
 #: includes/Subscriber.php:920
+#: includes/Rest/EventsController.php:922
 msgid "Details:"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:471
+msgid "Disabled"
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementModal.js:173
@@ -347,6 +542,7 @@ msgid "Display Start Date"
 msgstr ""
 
 #: includes/Announcement.php:214
+#: assets/js/src/components/admin/AnnouncementEditor.js:846
 #: assets/js/src/components/public/AnnouncementForm.js:499
 #: assets/js/src/components/public/AnnouncementDetails.js:198
 msgid "Display Window"
@@ -357,8 +553,20 @@ msgid "Display event-based announcements as a banner or modal."
 msgstr ""
 
 #: assets/js/src/components/public/EventModal.js:140
+#: assets/js/src/components/public/cards/EventCard.js:181
 #: assets/js/src/components/public/EventDetails.js:134
 msgid "Download Flyer"
+msgstr ""
+
+#: assets/js/src/components/admin/CssClassesDocs.js:37
+msgid "Dynamic CSS Classes"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:584
+#: assets/js/src/components/admin/AnnouncementEditor.js:1115
+#: assets/js/src/components/admin/Subscribers.js:414
+#: assets/js/src/components/admin/Settings.js:481
+msgid "Edit"
 msgstr ""
 
 #: includes/Announcement.php:38
@@ -369,24 +577,59 @@ msgstr ""
 msgid "Edit Event"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:388
+#: assets/js/src/components/admin/Subscribers.js:472
+msgid "Email"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:1191
+msgid "Email Recipients"
+msgstr ""
+
+#: assets/js/src/components/admin/ShortcodesDocs.js:553
+msgid "Email Subscription Form Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:500
+msgid "Email address"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:410
+msgid "Email addresses to receive event submission notifications. Multiple emails can be separated by commas or semicolons. Leave empty to send to all admins."
+msgstr ""
+
 #: includes/Rest/AnnouncementsController.php:400
 #: mayo-events-manager.php:657
 msgid "Email: %s"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:558
+msgid "Enable Source"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:471
+msgid "Enabled"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:889
+msgid "End"
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementForm.js:539
 msgid "End Date"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:292
 #: assets/js/src/components/public/EventForm.js:802
 msgid "End Date (optional)"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:211
 #: assets/js/src/components/public/EventForm.js:602
 msgid "End Date/Time"
 msgstr ""
 
-#: includes/Rest/EventsController.php:775
+#: includes/Rest/EventsController.php:959
 #: includes/Rest/AnnouncementsController.php:383
 msgid "End Date: %s"
 msgstr ""
@@ -395,12 +638,29 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: includes/Rest/EventsController.php:777
+#: includes/Rest/EventsController.php:961
 msgid "End Time: %s"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:307
+msgid "End of results"
+msgstr ""
+
+#: assets/js/src/components/public/cards/EventCard.js:152
 #: assets/js/src/components/public/EventDetails.js:188
 msgid "End:"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:518
+msgid "Enter a friendly name for this source (e.g., District 5 Website)"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:511
+msgid "Enter the URL of the WordPress site (e.g., https://example.com)"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:391
+msgid "Enter the URL of your BMLT root server (e.g., https://bmlt.example.org/main_server)"
 msgstr ""
 
 #: assets/js/src/components/public/SubscribeForm.js:147
@@ -413,13 +673,13 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:393
 #: assets/js/src/components/public/EventForm.js:406
+#: assets/js/src/components/public/AnnouncementForm.js:393
 msgid "Error reading the file"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:334
 #: assets/js/src/components/public/EventForm.js:343
+#: assets/js/src/components/public/AnnouncementForm.js:334
 msgid "Error submitting form"
 msgstr ""
 
@@ -431,8 +691,21 @@ msgstr ""
 msgid "Event #%d"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:174
+msgid "Event Details"
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:829
+#: assets/js/src/components/public/cards/EventCard.js:172
 msgid "Event Flyer"
+msgstr ""
+
+#: assets/js/src/components/admin/ShortcodesDocs.js:20
+msgid "Event List Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/ApiDocs.js:757
+msgid "Event Meta Fields"
 msgstr ""
 
 #: includes/Admin.php:219
@@ -440,16 +713,24 @@ msgstr ""
 msgid "Event Name"
 msgstr ""
 
-#: includes/Rest/EventsController.php:765
+#: includes/Rest/EventsController.php:949
 msgid "Event Name: %s"
 msgstr ""
 
+#: assets/js/src/components/admin/ShortcodesDocs.js:173
+msgid "Event Submission Form Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:178
+#: assets/js/src/components/admin/Settings.js:522
 #: assets/js/src/components/public/EventForm.js:513
+#: assets/js/src/components/public/cards/EventCard.js:159
+#: assets/js/src/components/public/EventFilters.js:7
 #: assets/js/src/components/public/EventDetails.js:168
 msgid "Event Type"
 msgstr ""
 
-#: includes/Rest/EventsController.php:767
+#: includes/Rest/EventsController.php:951
 msgid "Event Type: %s"
 msgstr ""
 
@@ -463,6 +744,10 @@ msgstr ""
 
 #: includes/Subscriber.php:926
 msgid "Event details unavailable from %s"
+msgstr ""
+
+#: assets/js/src/components/public/EventFilters.js:60
+msgid "Event filters"
 msgstr ""
 
 #: assets/js/src/components/public/EventDetails.js:28
@@ -483,19 +768,40 @@ msgstr ""
 msgid "Events will show as announcements when today's date is between the event's start and end dates."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:588
+#: assets/js/src/components/public/EventList.js:704
 msgid "Expand All"
 msgstr ""
 
 #: includes/Announcement.php:309
 #: includes/Announcement.php:391
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:537
 msgid "Expired"
 msgstr ""
 
+#: includes/Subscriber.php:924
 #: includes/Announcement.php:329
 #: includes/Announcement.php:601
-#: includes/Subscriber.php:924
 msgid "External"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:450
+msgid "External Event Sources"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:323
+msgid "External Link"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:203
+msgid "External source URL must use HTTPS protocol."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:273
+msgid "External source deleted successfully!"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:232
+msgid "External source saved successfully!"
 msgstr ""
 
 #: includes/Admin.php:190
@@ -504,6 +810,10 @@ msgstr ""
 
 #: includes/Admin.php:679
 msgid "Failed to create copy"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:276
+msgid "Failed to delete external source."
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementDetails.js:39
@@ -516,6 +826,22 @@ msgstr ""
 
 #: assets/js/src/components/public/EventArchive.js:35
 msgid "Failed to load events"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:161
+msgid "Failed to load settings. Please refresh the page and try again."
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:160
+msgid "Failed to load subscribers"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:235
+msgid "Failed to save external source."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:335
+msgid "Failed to save settings."
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementForm.js:329
@@ -538,14 +864,29 @@ msgstr ""
 msgid "February"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:147
 #: assets/js/src/components/public/EventForm.js:488
 msgid "Fifth"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:547
+msgid "Filter by categories (comma-separated)"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:540
+msgid "Filter by service body (optional)"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:554
+msgid "Filter by tags (comma-separated)"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:143
 #: assets/js/src/components/public/EventForm.js:484
 msgid "First"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:146
 #: assets/js/src/components/public/EventForm.js:487
 msgid "Fourth"
 msgstr ""
@@ -554,8 +895,9 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: includes/Rest/EventsController.php:694
+#: includes/Rest/EventsController.php:878
 #: assets/js/src/util.js:9
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:138
 #: assets/js/src/components/public/EventForm.js:478
 msgid "Friday"
 msgstr ""
@@ -564,12 +906,40 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:464
+msgid "Full address"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:492
+msgid "Full name of the contact person"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:328
+msgid "Generic Link"
+msgstr ""
+
 #: assets/js/src/components/public/CalendarView.js:316
 msgid "Go to Today"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:621
+#: assets/js/src/components/public/EventList.js:737
 msgid "Hide Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:181
+msgid "Hide past events"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:935
+msgid "High"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:324
+msgid "Hotel/Lodging"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:419
+msgid "Icon"
 msgstr ""
 
 #: includes/Subscriber.php:649
@@ -586,6 +956,10 @@ msgstr ""
 
 #: includes/Announcement.php:284
 msgid "Indefinite"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:325
+msgid "Information"
 msgstr ""
 
 #: includes/Admin.php:617
@@ -632,14 +1006,17 @@ msgstr ""
 msgid "June"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:148
 #: assets/js/src/components/public/EventForm.js:489
 msgid "Last"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:910
 #: assets/js/src/components/public/AnnouncementForm.js:565
 msgid "Leave empty to show indefinitely"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:879
 #: assets/js/src/components/public/AnnouncementForm.js:534
 msgid "Leave empty to start showing immediately"
 msgstr ""
@@ -648,11 +1025,31 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:1158
+msgid "Link Event"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:165
+msgid "Link Events"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:388
+msgid "Link Title"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:512
+msgid "Linked Announcements"
+msgstr ""
+
 #: includes/Announcement.php:216
 msgid "Linked Events"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:571
+#: assets/js/src/components/admin/AnnouncementEditor.js:985
+msgid "Links & Events"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:687
 msgid "List View"
 msgstr ""
 
@@ -660,19 +1057,32 @@ msgstr ""
 msgid "Loading announcement..."
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:996
+msgid "Loading details..."
+msgstr ""
+
 #: assets/js/src/components/public/EventDetails.js:41
 msgid "Loading event details..."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:537
-#: assets/js/src/components/public/EventArchive.js:45
+#: assets/js/src/components/admin/AnnouncementEditor.js:208
 #: assets/js/src/components/public/CalendarView.js:339
+#: assets/js/src/components/public/EventList.js:636
+#: assets/js/src/components/public/EventArchive.js:45
 msgid "Loading events..."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:667
-#: assets/js/src/components/public/EventList.js:672
+#: assets/js/src/components/public/EventList.js:783
+#: assets/js/src/components/public/EventList.js:788
 msgid "Loading more events..."
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:301
+msgid "Loading more..."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:344
+msgid "Loading settings..."
 msgstr ""
 
 #: assets/js/src/components/public/SubscribeForm.js:134
@@ -684,22 +1094,35 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:1065
+msgid "Local Event"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:327
+#: assets/js/src/components/public/cards/EventCard.js:195
 #: assets/js/src/components/public/EventDetails.js:150
 msgid "Location"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:449
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:469
 #: assets/js/src/components/public/EventForm.js:902
 msgid "Location Details"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:453
 #: assets/js/src/components/public/EventForm.js:880
 msgid "Location Name"
 msgstr ""
 
-#: includes/Rest/EventsController.php:730
 #: includes/Subscriber.php:917
-#: assets/js/src/components/public/EventList.js:504
+#: includes/Rest/EventsController.php:914
+#: assets/js/src/components/public/EventList.js:586
 msgid "Location:"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:933
+msgid "Low"
 msgstr ""
 
 #: mayo-events-manager.php:514
@@ -713,6 +1136,10 @@ msgstr ""
 #: includes/Subscriber.php:682
 #: includes/Subscriber.php:746
 msgid "Manage preferences / Unsubscribe:"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:366
+msgid "Manage specific dates when this recurring event should not occur."
 msgstr ""
 
 #: assets/js/src/util.js:15
@@ -737,6 +1164,10 @@ msgstr ""
 msgid "Mayo Event Announcements"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:351
+msgid "Mayo Events Manager Settings"
+msgstr ""
+
 #: includes/Admin.php:95
 msgid "Mayo Settings"
 msgstr ""
@@ -749,22 +1180,25 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: includes/Rest/EventsController.php:690
+#: includes/Rest/EventsController.php:874
 #: assets/js/src/util.js:5
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:134
 #: assets/js/src/components/public/EventForm.js:474
 msgid "Monday"
 msgstr ""
 
-#: includes/Rest/EventsController.php:705
+#: includes/Rest/EventsController.php:889
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:250
 #: assets/js/src/components/public/EventForm.js:669
 msgid "Monthly"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:305
 #: assets/js/src/components/public/EventForm.js:712
 msgid "Monthly Pattern"
 msgstr ""
 
-#: includes/Rest/EventsController.php:732
+#: includes/Rest/EventsController.php:916
 msgid "Name:"
 msgstr ""
 
@@ -772,7 +1206,7 @@ msgstr ""
 msgid "Name: %s"
 msgstr ""
 
-#: includes/Rest/EventsController.php:813
+#: includes/Rest/EventsController.php:997
 msgid "New Event Submission: %s"
 msgstr ""
 
@@ -785,9 +1219,14 @@ msgid "Next Month"
 msgstr ""
 
 #: assets/js/src/components/public/EventModal.js:70
+#: assets/js/src/components/public/cards/EventCard.js:95
+#: assets/js/src/components/public/cards/EventCard.js:102
+#: assets/js/src/components/public/cards/EventWidgetCard.js:43
+#: assets/js/src/components/public/cards/EventWidgetCard.js:49
 msgid "No Date Set"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:247
 #: assets/js/src/components/public/EventForm.js:666
 msgid "No Recurrence"
 msgstr ""
@@ -800,21 +1239,53 @@ msgstr ""
 msgid "No announcements found in trash"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:527
+msgid "No announcements linked to this event."
+msgstr ""
+
 #: assets/js/src/components/public/EventArchive.js:47
 msgid "No archived events found."
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:541
+#: assets/js/src/components/admin/AnnouncementEditor.js:214
+msgid "No events available"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:214
+msgid "No events found"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:652
 msgid "No events found in the archive."
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:616
+#: assets/js/src/components/public/EventList.js:650
+msgid "No events match the selected filters."
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:864
+#: assets/js/src/components/public/AnnouncementForm.js:616
 msgid "No file selected"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:544
+#: assets/js/src/components/admin/AnnouncementEditor.js:1310
+msgid "No matching subscribers"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:398
+msgid "No subscribers found."
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:122
+msgid "No subscription options configured. Configure them in the Settings page."
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:654
 msgid "No upcoming events found."
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:934
+msgid "Normal"
 msgstr ""
 
 #: includes/Rest/AnnouncementsController.php:369
@@ -827,6 +1298,10 @@ msgstr ""
 
 #: includes/Subscriber.php:650
 msgid "Note: If you don't see our emails, please check your spam or junk folder."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:404
+msgid "Notification Email"
 msgstr ""
 
 #: assets/js/src/util.js:23
@@ -849,36 +1324,72 @@ msgstr ""
 msgid "October"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:308
 #: assets/js/src/components/public/EventForm.js:726
 msgid "On a specific date"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:309
 #: assets/js/src/components/public/EventForm.js:740
 msgid "On a specific day"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:274
 #: assets/js/src/components/public/EventForm.js:690
 msgid "On these days"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:1093
+msgid "Open Link"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:651
+msgid "Opt-in: Existing subscribers must manually add new options"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:182
 msgid "Order:"
 msgstr ""
 
+#: assets/js/src/components/admin/ApiDocs.js:11
+msgid "Overview"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:472
+msgid "Parking info, entrance details, etc."
+msgstr ""
+
 #: includes/Admin.php:828
 msgid "Past events"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:66
+#: assets/js/src/components/admin/Subscribers.js:355
+msgid "Pending"
 msgstr ""
 
 #: includes/Subscriber.php:643
 msgid "Please confirm your subscription to %s announcements"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:358
+msgid "Please enter a valid URL (e.g., https://example.com)"
+msgstr ""
+
 #: includes/Subscriber.php:94
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:268
+#: assets/js/src/components/admin/Settings.js:315
+msgid "Please enter valid email addresses for notifications. Multiple emails can be separated by commas or semicolons."
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:409
+msgid "Please enter valid email addresses. Multiple emails can be separated by commas or semicolons."
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:254
+#: assets/js/src/components/public/AnnouncementForm.js:268
 msgid "Please fill in all required fields: %s"
 msgstr ""
 
@@ -886,14 +1397,23 @@ msgstr ""
 msgid "Please select at least one preference to subscribe."
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:486
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:481
+msgid "Point of Contact"
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:566
+#: assets/js/src/components/public/AnnouncementForm.js:486
 msgid "Point of Contact Email (Private)"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:473
 #: assets/js/src/components/public/EventForm.js:553
+#: assets/js/src/components/public/AnnouncementForm.js:473
 msgid "Point of Contact Name (Private)"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:392
+#: assets/js/src/components/admin/Subscribers.js:476
+msgid "Preferences"
 msgstr ""
 
 #: mayo-events-manager.php:280
@@ -908,16 +1428,22 @@ msgstr ""
 msgid "Previous Month"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:596
+#: assets/js/src/components/public/EventList.js:712
 msgid "Print Events"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:496
+#: assets/js/src/components/public/EventList.js:578
 msgid "Printed on"
 msgstr ""
 
 #: includes/Announcement.php:212
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:557
+#: assets/js/src/components/admin/AnnouncementEditor.js:928
 msgid "Priority"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:930
+msgid "Priority Level"
 msgstr ""
 
 #: includes/Subscriber.php:864
@@ -926,13 +1452,17 @@ msgid_plural "RELATED EVENTS"
 msgstr[0] ""
 msgstr[1] ""
 
-#: assets/js/src/components/public/cards/EventCard.js:250
-#: assets/js/src/components/public/cards/EventWidgetCard.js:66
+#: assets/js/src/components/public/EventList.js:730
+msgid "RSS Feed"
+msgstr ""
+
+#: assets/js/src/components/public/cards/EventCard.js:251
+#: assets/js/src/components/public/cards/EventWidgetCard.js:67
 msgid "Read More"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:614
-msgid "RSS Feed"
+#: assets/js/src/components/admin/AnnouncementEditor.js:1257
+msgid "Receives all announcements"
 msgstr ""
 
 #: includes/Admin.php:359
@@ -943,11 +1473,12 @@ msgstr ""
 msgid "Recurring Event"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:242
 #: assets/js/src/components/public/EventForm.js:647
 msgid "Recurring Pattern"
 msgstr ""
 
-#: includes/Rest/EventsController.php:672
+#: includes/Rest/EventsController.php:856
 msgid "Recurring Pattern:"
 msgstr ""
 
@@ -963,8 +1494,26 @@ msgstr ""
 msgid "Related:"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:380
+#: assets/js/src/components/admin/AnnouncementEditor.js:1133
+msgid "Remove"
+msgstr ""
+
+#: assets/js/src/components/public/EventFilters.js:101
+msgid "Remove filter %s"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:244
+msgid "Repeat"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:261
 #: assets/js/src/components/public/EventForm.js:675
 msgid "Repeat every"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:425
+msgid "Restricted Service Bodies"
 msgstr ""
 
 #: mayo-events-manager.php:392
@@ -979,18 +1528,35 @@ msgstr ""
 msgid "Sat"
 msgstr ""
 
-#: includes/Rest/EventsController.php:695
+#: includes/Rest/EventsController.php:879
 #: assets/js/src/util.js:10
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:139
 #: assets/js/src/components/public/EventForm.js:479
 msgid "Saturday"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:132
+msgid "Save Changes"
 msgstr ""
 
 #: mayo-events-manager.php:786
 msgid "Save Preferences"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:443
+#: assets/js/src/components/admin/Settings.js:666
+msgid "Save Settings"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:132
+#: assets/js/src/components/admin/Settings.js:443
+#: assets/js/src/components/admin/Settings.js:666
+msgid "Saving..."
+msgstr ""
+
 #: includes/Announcement.php:305
 #: includes/Announcement.php:390
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:537
 msgid "Scheduled"
 msgstr ""
 
@@ -998,6 +1564,23 @@ msgstr ""
 msgid "Search Announcements"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:172
+msgid "Search Events"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:371
+msgid "Search Subscribers:"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:377
+msgid "Search by email..."
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:175
+msgid "Search by event name..."
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:144
 #: assets/js/src/components/public/EventForm.js:485
 msgid "Second"
 msgstr ""
@@ -1006,13 +1589,20 @@ msgstr ""
 msgid "Security check failed"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:181
 #: assets/js/src/components/public/EventForm.js:522
 msgid "Select Event Type"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:459
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:435
+#: assets/js/src/components/admin/AnnouncementEditor.js:960
 #: assets/js/src/components/public/EventForm.js:539
+#: assets/js/src/components/public/AnnouncementForm.js:459
 msgid "Select a service body"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:533
+msgid "Select the event type"
 msgstr ""
 
 #: assets/js/src/components/public/SubscribeForm.js:157
@@ -1020,8 +1610,12 @@ msgstr ""
 msgid "Select what you'd like to receive notifications about:"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:615
+#: assets/js/src/components/admin/Subscribers.js:75
+msgid "Select which categories, tags, and service bodies this subscriber should receive notifications for. If none are selected, they will receive all announcements."
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:863
+#: assets/js/src/components/public/AnnouncementForm.js:615
 msgid "Selected: %s"
 msgstr ""
 
@@ -1033,19 +1627,33 @@ msgstr ""
 msgid "September"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:182
+#: assets/js/src/components/admin/Settings.js:527
 #: assets/js/src/components/public/EventForm.js:523
 msgid "Service"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:108
 #: assets/js/src/components/public/SubscribeForm.js:200
 #: mayo-events-manager.php:752
 msgid "Service Bodies"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:626
+msgid "Service Bodies available for subscription:"
+msgstr ""
+
 #: includes/Announcement.php:213
 #: includes/Admin.php:224
-#: assets/js/src/components/public/AnnouncementForm.js:451
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:430
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:432
+#: assets/js/src/components/admin/AnnouncementEditor.js:955
+#: assets/js/src/components/admin/AnnouncementEditor.js:957
+#: assets/js/src/components/admin/Settings.js:537
 #: assets/js/src/components/public/EventForm.js:531
+#: assets/js/src/components/public/cards/EventCard.js:212
+#: assets/js/src/components/public/AnnouncementForm.js:451
+#: assets/js/src/components/public/EventFilters.js:12
 #: assets/js/src/components/public/EventDetails.js:175
 #: assets/js/src/components/public/AnnouncementDetails.js:191
 msgid "Service Body"
@@ -1056,15 +1664,20 @@ msgstr ""
 msgid "Service Body (%s)"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:422
+msgid "Service Body Configuration"
+msgstr ""
+
 #: includes/Rest/AnnouncementsController.php:392
 msgid "Service Body ID: %s"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:469
 #: assets/js/src/components/public/EventArchive.js:127
 msgid "Service Body:"
 msgstr ""
 
-#: includes/Rest/EventsController.php:769
+#: includes/Rest/EventsController.php:953
 msgid "Service Body: %1$s (ID: %2$s)"
 msgstr ""
 
@@ -1072,36 +1685,62 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:630
+#: assets/js/src/components/admin/Settings.js:332
+msgid "Settings saved successfully!"
+msgstr ""
+
+#: assets/js/src/components/public/EventList.js:746
 msgid "Shortcode for this event list:"
 msgstr ""
 
 #: includes/Admin.php:86
 #: includes/Admin.php:87
+#: assets/js/src/components/admin/ShortcodesDocs.js:6
 msgid "Shortcodes"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:621
+#: assets/js/src/components/public/EventList.js:737
 msgid "Show Shortcode"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:508
+msgid "Site URL"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:371
+msgid "Skipped Dates:"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:364
+msgid "Skipped Occurrences"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:162
 msgid "Sort By:"
 msgstr ""
 
+#: assets/js/src/components/admin/Settings.js:515
+msgid "Source Name"
+msgstr ""
+
 #: includes/Subscriber.php:883
 msgid "Source:"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:858
+msgid "Start"
 msgstr ""
 
 #: assets/js/src/components/public/AnnouncementForm.js:508
 msgid "Start Date"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:193
 #: assets/js/src/components/public/EventForm.js:580
 msgid "Start Date/Time"
 msgstr ""
 
-#: includes/Rest/EventsController.php:771
+#: includes/Rest/EventsController.php:955
 #: includes/Rest/AnnouncementsController.php:381
 msgid "Start Date: %s"
 msgstr ""
@@ -1110,16 +1749,20 @@ msgstr ""
 msgid "Start Time"
 msgstr ""
 
-#: includes/Rest/EventsController.php:773
+#: includes/Rest/EventsController.php:957
 msgid "Start Time: %s"
 msgstr ""
 
+#: assets/js/src/components/public/cards/EventCard.js:147
 #: assets/js/src/components/public/EventDetails.js:183
 msgid "Start:"
 msgstr ""
 
 #: includes/Announcement.php:215
 #: includes/Admin.php:223
+#: assets/js/src/components/admin/Subscribers.js:62
+#: assets/js/src/components/admin/Subscribers.js:389
+#: assets/js/src/components/admin/Subscribers.js:473
 msgid "Status"
 msgstr ""
 
@@ -1135,8 +1778,8 @@ msgstr ""
 msgid "Submitted by:"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:683
 #: assets/js/src/components/public/EventForm.js:959
+#: assets/js/src/components/public/AnnouncementForm.js:683
 msgid "Submitting..."
 msgstr ""
 
@@ -1144,8 +1787,16 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:390
+#: assets/js/src/components/admin/Subscribers.js:474
+msgid "Subscribed"
+msgstr ""
+
 #: includes/Admin.php:76
 #: includes/Admin.php:77
+#: assets/js/src/components/admin/Subscribers.js:303
+#: assets/js/src/components/admin/Subscribers.js:315
+#: assets/js/src/components/admin/Subscribers.js:326
 msgid "Subscribers"
 msgstr ""
 
@@ -1157,6 +1808,11 @@ msgstr ""
 msgid "Subscription Confirmed"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:73
+#: assets/js/src/components/admin/Settings.js:587
+msgid "Subscription Preferences"
+msgstr ""
+
 #: mayo-events-manager.php:420
 msgid "Subscription not found."
 msgstr ""
@@ -1165,22 +1821,34 @@ msgstr ""
 msgid "Sun"
 msgstr ""
 
-#: includes/Rest/EventsController.php:689
+#: includes/Rest/EventsController.php:873
 #: assets/js/src/util.js:4
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:133
 #: assets/js/src/components/public/EventForm.js:473
 msgid "Sunday"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:604
 #: assets/js/src/components/public/EventForm.js:847
+#: assets/js/src/components/public/AnnouncementForm.js:604
 msgid "Supported file types: Images (.jpg, .jpeg, .png, .gif)"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:657
+#: assets/js/src/components/admin/ShortcodesDocs.js:9
+#: assets/js/src/components/admin/ApiDocs.js:17
+msgid "Table of Contents"
+msgstr ""
+
+#: assets/js/src/components/public/EventFilters.js:22
+msgid "Tag"
+msgstr ""
+
+#: assets/js/src/components/admin/Subscribers.js:94
+#: assets/js/src/components/admin/Settings.js:551
 #: assets/js/src/components/public/EventForm.js:934
+#: assets/js/src/components/public/AnnouncementForm.js:657
+#: assets/js/src/components/public/SubscribeForm.js:181
 #: assets/js/src/components/public/EventDetails.js:212
 #: assets/js/src/components/public/AnnouncementDetails.js:221
-#: assets/js/src/components/public/SubscribeForm.js:181
 #: mayo-events-manager.php:718
 msgid "Tags"
 msgstr ""
@@ -1189,7 +1857,11 @@ msgstr ""
 msgid "Tags (comma-separated slugs):"
 msgstr ""
 
-#: includes/Rest/EventsController.php:750
+#: assets/js/src/components/admin/Settings.js:610
+msgid "Tags available for subscription:"
+msgstr ""
+
+#: includes/Rest/EventsController.php:934
 msgid "Tags:"
 msgstr ""
 
@@ -1217,6 +1889,7 @@ msgstr ""
 msgid "The selected file is not a valid image. Please use a valid image file (JPG, PNG, or GIF)"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:145
 #: assets/js/src/components/public/EventForm.js:486
 msgid "Third"
 msgstr ""
@@ -1259,10 +1932,16 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: includes/Rest/EventsController.php:693
+#: includes/Rest/EventsController.php:877
 #: assets/js/src/util.js:8
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:137
 #: assets/js/src/components/public/EventForm.js:477
 msgid "Thursday"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:870
+#: assets/js/src/components/admin/AnnouncementEditor.js:901
+msgid "Time"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:119
@@ -1273,11 +1952,13 @@ msgstr ""
 msgid "Time:"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:230
+#: assets/js/src/components/admin/AnnouncementEditor.js:915
 #: assets/js/src/components/public/EventForm.js:625
 msgid "Timezone"
 msgstr ""
 
-#: includes/Rest/EventsController.php:779
+#: includes/Rest/EventsController.php:963
 msgid "Timezone: %s"
 msgstr ""
 
@@ -1298,8 +1979,9 @@ msgstr ""
 msgid "Tue"
 msgstr ""
 
-#: includes/Rest/EventsController.php:691
+#: includes/Rest/EventsController.php:875
 #: assets/js/src/util.js:6
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:135
 #: assets/js/src/components/public/EventForm.js:475
 msgid "Tuesday"
 msgstr ""
@@ -1308,15 +1990,30 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:503
+#: assets/js/src/components/admin/Settings.js:468
+#: assets/js/src/components/public/EventList.js:585
 #: assets/js/src/components/public/EventArchive.js:77
 msgid "Type:"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:399
+msgid "URL"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:350
+msgid "URL is required"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:390
+msgid "URL must start with 'https://'"
+msgstr ""
+
 #: includes/Announcement.php:238
 #: includes/Admin.php:273
-#: assets/js/src/components/public/AnnouncementForm.js:461
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:436
+#: assets/js/src/components/admin/AnnouncementEditor.js:961
 #: assets/js/src/components/public/EventForm.js:541
+#: assets/js/src/components/public/AnnouncementForm.js:461
 msgid "Unaffiliated (0)"
 msgstr ""
 
@@ -1324,13 +2021,17 @@ msgstr ""
 msgid "Unknown Event"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:648
+#: assets/js/src/components/admin/AnnouncementEditor.js:289
+msgid "Unlink"
+msgstr ""
+
 #: assets/js/src/components/public/EventForm.js:927
+#: assets/js/src/components/public/AnnouncementForm.js:648
 msgid "Unnamed Category"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:671
 #: assets/js/src/components/public/EventForm.js:948
+#: assets/js/src/components/public/AnnouncementForm.js:671
 msgid "Unnamed Tag"
 msgstr ""
 
@@ -1343,6 +2044,8 @@ msgstr ""
 msgid "Unsubscribe Error"
 msgstr ""
 
+#: assets/js/src/components/admin/Subscribers.js:67
+#: assets/js/src/components/admin/Subscribers.js:364
 #: mayo-events-manager.php:252
 msgid "Unsubscribed"
 msgstr ""
@@ -1363,6 +2066,18 @@ msgstr ""
 msgid "Upload Image"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:936
+msgid "Urgent"
+msgstr ""
+
+#: assets/js/src/components/admin/ApiDocs.js:941
+msgid "Usage Examples"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:1093
+msgid "View"
+msgstr ""
+
 #: includes/Announcement.php:39
 msgid "View Announcement"
 msgstr ""
@@ -1379,15 +2094,19 @@ msgstr ""
 msgid "View Full Details"
 msgstr ""
 
+#: assets/js/src/components/admin/AnnouncementEditor.js:1093
+msgid "View on External Site"
+msgstr ""
+
 #: includes/Subscriber.php:744
 msgid "View online:"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:546
+#: assets/js/src/components/public/EventList.js:656
 msgid "View past events"
 msgstr ""
 
-#: includes/Rest/EventsController.php:795
+#: includes/Rest/EventsController.php:979
 msgid "View the event: %s"
 msgstr ""
 
@@ -1395,23 +2114,30 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: includes/Rest/EventsController.php:692
+#: includes/Rest/EventsController.php:876
 #: assets/js/src/util.js:7
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:136
 #: assets/js/src/components/public/EventForm.js:476
 msgid "Wednesday"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:331
 #: assets/js/src/components/public/EventForm.js:761
 msgid "Week"
 msgstr ""
 
-#: includes/Rest/EventsController.php:682
+#: includes/Rest/EventsController.php:866
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:249
 #: assets/js/src/components/public/EventForm.js:668
 msgid "Weekly"
 msgstr ""
 
 #: includes/Subscriber.php:676
 msgid "Welcome to %s announcements"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:646
+msgid "When new options are added:"
 msgstr ""
 
 #: assets/js/src/components/public/EventArchive.js:82
@@ -1458,13 +2184,13 @@ msgstr ""
 msgid "Your Preferences"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:494
 #: assets/js/src/components/public/EventForm.js:574
+#: assets/js/src/components/public/AnnouncementForm.js:494
 msgid "Your email address (will not be displayed publicly)"
 msgstr ""
 
-#: assets/js/src/components/public/AnnouncementForm.js:481
 #: assets/js/src/components/public/EventForm.js:561
+#: assets/js/src/components/public/AnnouncementForm.js:481
 msgid "Your name (will not be displayed publicly)"
 msgstr ""
 
@@ -1484,17 +2210,32 @@ msgstr ""
 msgid "[%1$s] New Announcement Submission: %2$s"
 msgstr ""
 
-#: assets/js/src/components/public/EventList.js:502
-#: assets/js/src/components/public/EventArchive.js:84
-#: assets/js/src/components/public/EventArchive.js:87
+#: assets/js/src/components/public/cards/EventCard.js:147
+#: assets/js/src/components/public/cards/EventCard.js:152
+#: assets/js/src/components/public/EventList.js:584
 #: assets/js/src/components/public/EventDetails.js:183
 #: assets/js/src/components/public/EventDetails.js:188
 #: assets/js/src/components/public/AnnouncementDetails.js:98
+#: assets/js/src/components/public/EventArchive.js:84
+#: assets/js/src/components/public/EventArchive.js:87
 msgid "at"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:267
 #: assets/js/src/components/public/EventForm.js:683
 msgid "days"
+msgstr ""
+
+#: assets/js/src/components/admin/Settings.js:429
+msgid "e.g., 1,2,3,0"
+msgstr ""
+
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:456
+msgid "e.g., Community Center"
+msgstr ""
+
+#: assets/js/src/components/admin/AnnouncementEditor.js:391
+msgid "e.g., Hotel Reservations"
 msgstr ""
 
 #: includes/Widgets/AnnouncementWidget.php:101
@@ -1521,17 +2262,18 @@ msgstr ""
 msgid "last"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:268
 #: assets/js/src/components/public/EventForm.js:684
 msgid "months"
 msgstr ""
 
-#: includes/Rest/EventsController.php:701
-#: includes/Rest/EventsController.php:715
+#: includes/Rest/EventsController.php:885
+#: includes/Rest/EventsController.php:899
 #: assets/js/src/util.js:125
 msgid "on %s"
 msgstr ""
 
-#: includes/Rest/EventsController.php:712
+#: includes/Rest/EventsController.php:896
 #: assets/js/src/util.js:141
 msgid "on day %s"
 msgstr ""
@@ -1548,11 +2290,12 @@ msgstr ""
 msgid "third"
 msgstr ""
 
-#: includes/Rest/EventsController.php:722
+#: includes/Rest/EventsController.php:906
 #: assets/js/src/util.js:169
 msgid "until %s"
 msgstr ""
 
+#: assets/js/src/components/admin/EventBlockEditorSidebar.js:268
 #: assets/js/src/components/public/EventForm.js:684
 msgid "weeks"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mayo",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mayo",
-      "version": "1.8.9",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-react": "^7.26.3",

--- a/readme.txt
+++ b/readme.txt
@@ -188,7 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.0 =
-* Added pill-style filter chips above the event list and calendar so visitors can toggle one or more event types, service bodies, categories, or tags (OR within each facet, AND across facets). Options are populated from the actual events in scope, including service bodies surfaced by external feeds, and any filter pinned by a shortcode attribute stays locked. [#251]
+* Added a filter bar above the event list and calendar. Visitors pick filters from compact dropdowns (event type, service body, category, tag); selected values appear as removable chips and combine with OR semantics within a facet and AND across facets. Options are populated from the actual events in scope, including service bodies surfaced by external feeds, and any filter pinned by a shortcode attribute stays locked. [#251]
 * Fixed issue with long caching mechanisms like Cloudflare to avoid using nonces for readonly API calls [#271]
 * Added multilingual support: the plugin now declares the `mayo-events-manager` text domain, ships a `languages/mayo-events-manager.pot` template, and loads PHP and JavaScript translations so events, announcements, forms, subscription pages, and admin labels can be translated into any locale. [#268]
 * Added pre-populated translation files for Spanish (es_ES), Portuguese-Brazil (pt_BR), and French (fr_FR) with best-guess translations for all 354 strings. [#268]

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.0 =
+* Added display filter dropdowns above the event list and calendar so visitors can narrow events by event type, service body, category, and tag. Options are populated from the actual events in scope, including service bodies surfaced by external feeds, and any filter pinned by a shortcode attribute stays locked. [#251]
 * Fixed issue with long caching mechanisms like Cloudflare to avoid using nonces for readonly API calls [#271]
 * Added multilingual support: the plugin now declares the `mayo-events-manager` text domain, ships a `languages/mayo-events-manager.pot` template, and loads PHP and JavaScript translations so events, announcements, forms, subscription pages, and admin labels can be translated into any locale. [#268]
 * Added pre-populated translation files for Spanish (es_ES), Portuguese-Brazil (pt_BR), and French (fr_FR) with best-guess translations for all 354 strings. [#268]

--- a/readme.txt
+++ b/readme.txt
@@ -188,7 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.0 =
-* Added display filter dropdowns above the event list and calendar so visitors can narrow events by event type, service body, category, and tag. Options are populated from the actual events in scope, including service bodies surfaced by external feeds, and any filter pinned by a shortcode attribute stays locked. [#251]
+* Added pill-style filter chips above the event list and calendar so visitors can toggle one or more event types, service bodies, categories, or tags (OR within each facet, AND across facets). Options are populated from the actual events in scope, including service bodies surfaced by external feeds, and any filter pinned by a shortcode attribute stays locked. [#251]
 * Fixed issue with long caching mechanisms like Cloudflare to avoid using nonces for readonly API calls [#271]
 * Added multilingual support: the plugin now declares the `mayo-events-manager` text domain, ships a `languages/mayo-events-manager.pot` template, and loads PHP and JavaScript translations so events, announcements, forms, subscription pages, and admin labels can be translated into any locale. [#268]
 * Added pre-populated translation files for Spanish (es_ES), Portuguese-Brazil (pt_BR), and French (fr_FR) with best-guess translations for all 354 strings. [#268]


### PR DESCRIPTION
Closes #251

## Summary
- New filter bar above `[mayo_event_list]` (both list and calendar views) lets visitors narrow events by **event type**, **service body**, **category**, and **tag**.
- Options are data-driven via a new `GET /event-manager/v1/events/facets` endpoint that walks the full (unpaginated) result set, including events from external feeds, so service bodies surfaced by external sources appear in the dropdown automatically.
- Shortcode-pinned filters (e.g. `[mayo_event_list event_type="Service"]`) stay locked — the corresponding dropdown is hidden so visitors can't widen scope past what the site admin allowed.
- A facet whose value list is empty is also hidden, so instances that don't use categories/tags don't see useless empty dropdowns.
- Widget renderings of `[mayo_event_list]` do not render the filter bar (compact context).
- Honors `mayo-events-manager` text domain on every new string (PHP + JS).
- Adds a changelog entry under the current unreleased version `1.9.0` in `readme.txt` per `CLAUDE.md`.

## Files changed
- `includes/Rest/EventsController.php` — register `/events/facets` route + handler.
- `assets/js/src/components/public/EventFilters.js` — **new** filter bar component.
- `assets/js/src/components/public/EventList.js` — fetch facets, manage `activeFilters` state, render `<EventFilters>` above list/calendar, thread selections through `fetchEvents`/`fetchCalendarEvents`.
- `assets/css/public.css` — styling for `.mayo-event-filters` row.
- `readme.txt` — changelog entry under `1.9.0`.

## Test plan
- [ ] `npm run build` succeeds (verified locally).
- [ ] `composer lint` and `composer lint:esc-url` pass (verified locally).
- [ ] Load a page with `[mayo_event_list]` — filter bar appears with populated dropdowns for the facets present in the data.
- [ ] Pick a value in each dropdown — list refreshes to the narrowed set; URL is unchanged (filter is in-memory state).
- [ ] Switch from list to calendar view — selection is preserved and the calendar re-fetches with the same filters.
- [ ] Add `[mayo_event_list event_type="Service"]` — event-type dropdown is hidden while the others remain.
- [ ] Configure an external source under Settings → External Sources — service bodies from that source appear in the dropdown with the correct names.
- [ ] Add `[mayo_event_list source_ids="external-1"]` — facet options reflect only that external source's events.
- [ ] `[mayo_event_list]` inside a Text widget — no filter bar (widget mode skipped).
- [ ] "Clear filters" button resets all dropdowns and reloads the unfiltered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)