### PR TITLE
Install gettext in release/latest workflows so msgfmt is available

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -40,6 +40,9 @@ jobs:
         uses: actions/checkout@v6
         id: code-checkout
 
+      - name: Install gettext (for msgfmt) 🌐
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gettext
+
       - name: Prepare to deploy 🔧
         run: |
           export FILENAME=${PLUGIN}-build-${GITHUB_RUN_NUMBER}-${GITHUB_SHA}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check out code 🛒
         uses: actions/checkout@v6
 
+      - name: Install gettext (for msgfmt) 🌐
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gettext
+
       - name: Build package 🔧
         id: build-package
         run: |


### PR DESCRIPTION
Follow-up to #275 (which closed #273).

## Summary
- The post-merge `latest` workflow run on PR #275 failed at `make mo` with `/bin/sh: 1: msgfmt: not found` ([run 25997974092](https://github.com/bmlt-enabled/mayo/actions/runs/25997974092)).
- My original assumption that `msgfmt` is preinstalled on the `ubuntu-24.04` runner was wrong.
- Add `sudo apt-get install -y --no-install-recommends gettext` before `make build` in both `latest.yml` (`deploy` job) and `release.yml` (`package` job). Cheap (~1s) and deterministic.
- CI's `lint`/`test` jobs don't run `make build`, so no change there.

## Test plan
- [ ] PR's `CI` workflow (lint + test) is green — unchanged path.
- [ ] After merge, the `latest` workflow on `main` succeeds; `make mo` produces the `.mo` files and the zip is uploaded to S3.
- [ ] Next tag push: `release` workflow's `package` job succeeds for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)