### PR TITLE
Update build-time axios dependency to 1.16.1 to resolve security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mayo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mayo",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-react": "^7.26.3",
@@ -9270,14 +9270,49 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -13163,9 +13198,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.1 =
+* Updated the build-time axios dependency to resolve npm security advisories. The dependency is dev-only and never ships to site visitors. [#284]
 * Added validation of the BMLT root server URL on save: malformed URLs and hosts that aren't a reachable BMLT root server are now rejected with a clear error instead of being saved silently, plus a "Test connection" button in Settings to verify the server without saving. [#282]
 * Fixed external feed sources ignoring the visitor's event type and service body filters; user-selected filters now override each source's admin-pinned defaults so a "Service" filter no longer surfaces "Activity" events pulled from a remote feed. [#279]
 * Added a subscribable ICS calendar feed so Google Calendar, Apple Calendar, and Outlook keep syncing newly approved events automatically. The calendar icon on the event list now opens a Subscribe panel with the feed URL, a webcal:// quick-subscribe link, a one-time .ics download, and Google Calendar instructions. Recurring events now emit proper RRULE/EXDATE so series display as a single repeating event in subscribers' calendars instead of one-shot duplicates, and each event's original timezone is preserved via VTIMEZONE blocks. [#277]


### PR DESCRIPTION
Closes #284

## What

Bumps the transitive **axios** dependency from **1.13.2 → 1.16.1** in `package-lock.json`.

## Why

axios is **not** a direct dependency — it's pulled in only by the dev/build toolchain (`@wordpress/scripts → jest-dev-server → wait-on → axios`) and does **not** appear in any shipped bundle (`assets/js/dist/`), so the vulnerable code never reaches WordPress users. The lockfile resolved 1.13.2, which is below the **1.15.1** patch line for a batch of advisories (prototype pollution, header injection, NO_PROXY bypass, CRLF injection, SSRF, etc.). This clears `npm audit` and keeps the dev toolchain current.

`wait-on` already declares `axios: "^1.12.1"`, which permits 1.16.1, so **no `overrides` block was needed** — only `package-lock.json` changed (`package.json` is untouched, axios stays transitive).

## Verification

- `grep -A1 '"node_modules/axios"' package-lock.json` → `"version": "1.16.1"`
- `npm audit` → no axios advisories
- `npm run build` → compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)