### PR TITLE
Bump declared WordPress support to 7.0

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -4,6 +4,8 @@
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
  * Version: 1.9.1
+ * Requires at least: 6.7
+ * Tested up to: 7.0
  * Author: bmlt-enabled
  * License: GPLv2 or later
  * Author URI: https://bmlt.app

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: bmltenabled, radius314
 Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.1 =
+* Bumped declared WordPress compatibility to 7.0 (Tested up to) and added matching `Requires at least` and `Tested up to` headers to the main plugin file so the WordPress.org parser sees consistent values. [#286]
 * Updated the build-time axios dependency to resolve npm security advisories. The dependency is dev-only and never ships to site visitors. [#284]
 * Added validation of the BMLT root server URL on save: malformed URLs and hosts that aren't a reachable BMLT root server are now rejected with a clear error instead of being saved silently, plus a "Test connection" button in Settings to verify the server without saving. [#282]
 * Fixed external feed sources ignoring the visitor's event type and service body filters; user-selected filters now override each source's admin-pinned defaults so a "Service" filter no longer surfaces "Activity" events pulled from a remote feed. [#279]


### PR DESCRIPTION
Closes #286

## Summary
- `readme.txt`: bumped `Tested up to` from 6.9 → 7.0.
- `mayo-events-manager.php`: added the missing `Requires at least: 6.7` and `Tested up to: 7.0` headers so the WP.org parser sees consistent values in both the plugin header and readme.
- `Requires at least` kept at 6.7 to avoid locking out existing 6.x sites.
- Changelog entry added under the unreleased `= 1.9.1 =` section in `readme.txt`.

## Out of scope
No CI workflow / `composer.json` / `package.json` changes — none of them pin a WordPress version.

## Note on verification
WordPress 7.0 is not GA as of this change. Fresh-install verification against the released build is pending — to be re-run once 7.0 ships (or against a public beta if/when one is available).

## Test plan
- [x] `composer install`
- [x] `composer test` — 526 tests, 1179 assertions, all passing
- [x] `composer lint` — no new violations on changed lines (4 pre-existing PHPCS errors on lines 1/23/123 are unrelated to this change)
- [x] Verified `Requires at least` and `Tested up to` values match between `mayo-events-manager.php` and `readme.txt`
- [ ] Manual install against WP 7.0 once GA (pending release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)