### PR TITLE
Fix event list filter bar: canonical event types + disable while loading

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1885,6 +1885,16 @@
     border-radius: 4px;
 }
 
+/* Inert while the event list is fetching, so toggling can't race the response. */
+.mayo-event-filters.is-disabled {
+    opacity: 0.55;
+}
+
+.mayo-event-filters.is-disabled .mayo-event-filter-pill,
+.mayo-event-filters.is-disabled .mayo-event-filter-clear {
+    cursor: not-allowed;
+}
+
 .mayo-event-filter-pill-wrap {
     position: relative;
     display: inline-flex;

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -43,7 +43,7 @@ const normalizeOptions = (key, facets) => {
     return [];
 };
 
-const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) => {
+const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters, disabled = false }) => {
     const containerRef = useRef(null);
     const [openFacet, setOpenFacet] = useState(null);
 
@@ -86,9 +86,10 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) =>
 
     return (
         <div
-            className="mayo-event-filters"
+            className={'mayo-event-filters' + (disabled ? ' is-disabled' : '')}
             role="region"
             aria-label={__('Event filters', 'mayo-events-manager')}
+            aria-busy={disabled}
             ref={containerRef}
         >
             {visibleFacets.map(def => {
@@ -110,7 +111,13 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) =>
                             aria-haspopup="listbox"
                             aria-expanded={isOpen}
                             aria-controls={panelId}
-                            onClick={() => setOpenFacet(isOpen ? null : def.key)}
+                            disabled={disabled}
+                            onClick={() => {
+                                if (disabled) {
+                                    return;
+                                }
+                                setOpenFacet(isOpen ? null : def.key);
+                            }}
                         >
                             <span className="mayo-event-filter-pill-label">{label}</span>
                             {count > 0 && (
@@ -153,7 +160,12 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) =>
                                                     }
                                                     role="option"
                                                     aria-selected={isActive}
-                                                    onClick={() => onToggle(def.key, option.value)}
+                                                    disabled={disabled}
+                                                    onClick={() => {
+                                                        if (!disabled) {
+                                                            onToggle(def.key, option.value);
+                                                        }
+                                                    }}
                                                 >
                                                     {option.label}
                                                 </button>
@@ -170,7 +182,12 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters }) =>
                 <button
                     type="button"
                     className="mayo-event-filter-clear"
-                    onClick={onClear}
+                    disabled={disabled}
+                    onClick={() => {
+                        if (!disabled) {
+                            onClear();
+                        }
+                    }}
                     title={__('Clear filters', 'mayo-events-manager')}
                     aria-label={__('Clear filters', 'mayo-events-manager')}
                 >

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -644,6 +644,7 @@ const EventList = ({ widget = false, settings = {} }) => {
             onToggle={handleToggleFilter}
             onClear={handleClearFilters}
             lockedFilters={lockedFilters}
+            disabled={loading}
         />
     ) : null);
 

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -19,6 +19,18 @@ use BmltEnabled\Mayo\Rest\Helpers\ServiceBodyLookup;
 class EventsController {
 
     /**
+     * Canonical set of event types. This is a fixed enumeration (not data-derived),
+     * so the filter facet always offers the full set regardless of which events are
+     * currently scheduled. Keep in sync with the JS dropdowns that submit/edit events:
+     *   assets/js/src/components/public/EventForm.js
+     *   assets/js/src/components/admin/Settings.js
+     *   assets/js/src/components/admin/EventBlockEditorSidebar.js
+     *
+     * @var string[]
+     */
+    const EVENT_TYPES = ['Service', 'Activity', 'Celebration'];
+
+    /**
      * Register REST API routes for events
      */
     public static function register_routes() {
@@ -377,7 +389,11 @@ class EventsController {
             }
         }
 
-        $event_types = [];
+        // Event type is a fixed enumeration, so the facet is always the canonical
+        // list (not scanned from event meta) — otherwise types with no scheduled
+        // events would silently drop out of the filter. service_body / categories /
+        // tags below remain legitimately data-derived.
+        $event_types = self::EVENT_TYPES;
         $service_bodies = [];
         $service_body_seen = [];
         $categories = [];
@@ -386,11 +402,6 @@ class EventsController {
         $tag_seen = [];
 
         foreach ($events as $event) {
-            $type = isset($event['meta']['event_type']) ? trim((string) $event['meta']['event_type']) : '';
-            if ($type !== '' && !in_array($type, $event_types, true)) {
-                $event_types[] = $type;
-            }
-
             $service_body_id = isset($event['meta']['service_body']) ? trim((string) $event['meta']['service_body']) : '';
             if ($service_body_id !== '') {
                 $source_id = isset($event['source_id']) ? (string) $event['source_id'] : 'local';

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.1 =
+* Fixed the event list filter bar omitting event types that had no currently scheduled events; the Event Type filter now always offers the full set (Service, Activity, Celebration) regardless of what's on the calendar. [#290]
 * Added an optional private phone-number contact field to the event and announcement submission forms. It is hidden by default and enabled per-form with the new `show_phone` shortcode option; add `phone` to `additional_required_fields` to make it mandatory. Like the contact email, the number is stored privately for organizers and is never displayed publicly. [#288]
 * Bumped declared WordPress compatibility to 7.0 (Tested up to) and added matching `Requires at least` and `Tested up to` headers to the main plugin file so the WordPress.org parser sees consistent values. [#286]
 * Updated the build-time axios dependency to resolve npm security advisories. The dependency is dev-only and never ships to site visitors. [#284]

--- a/readme.txt
+++ b/readme.txt
@@ -189,6 +189,7 @@ This project is licensed under the GPL v2 or later.
 
 = 1.9.1 =
 * Fixed the event list filter bar omitting event types that had no currently scheduled events; the Event Type filter now always offers the full set (Service, Activity, Celebration) regardless of what's on the calendar. [#290]
+* Fixed a race where toggling filters while the event list was still loading could leave the selection in an inconsistent state; the filter bar is now disabled (greyed out) while a request is in flight. [#290]
 * Added an optional private phone-number contact field to the event and announcement submission forms. It is hidden by default and enabled per-form with the new `show_phone` shortcode option; add `phone` to `additional_required_fields` to make it mandatory. Like the contact email, the number is stored privately for organizers and is never displayed publicly. [#288]
 * Bumped declared WordPress compatibility to 7.0 (Tested up to) and added matching `Requires at least` and `Tested up to` headers to the main plugin file so the WordPress.org parser sees consistent values. [#286]
 * Updated the build-time axios dependency to resolve npm security advisories. The dependency is dev-only and never ships to site visitors. [#284]


### PR DESCRIPTION
Closes #290

Two unrelated filter-bar bugs, fixed as two atomic commits a reviewer can land/revert independently.

## Fix #1 — canonical Event Type facet (commit `dc4ac1c`)
The Event Type filter was *data-derived*: `EventsController::get_events_facets()` collected distinct `event_type` meta values from the in-scope events, so any type with **no currently scheduled events** silently dropped out of the filter.

**Approach: option (a)** — the canonical list is hardcoded in PHP as a `const EVENT_TYPES = ['Service', 'Activity', 'Celebration'];` on `EventsController`, with a comment cross-referencing the three JS dropdowns that already define the same enum (`EventForm.js`, `Settings.js`, `EventBlockEditorSidebar.js`). `get_events_facets()` now seeds `$event_types` from that constant instead of scanning event meta.

I deliberately did **not** extract a shared JS constant (option b): each JS consumer wraps its labels in literal `__('Service', …)` calls for POT string extraction; swapping those for a variable (`__(type, …)`) would break i18n extraction, so a shared module wouldn't reduce code and would risk a translation regression.

- ✅ **Celebration now renders** in the Event Type filter even on a window with **zero** Celebration events (the facet is the fixed enum, no longer scanned from data).
- ✅ **`service_body` / `categories` / `tags` are unchanged** — still legitimately data-derived from the in-scope events in the same loop; only the `event_types` branch changed.
- The frontend already renders whatever `event_types` the server returns, so no consumer change was needed. The `EventFilters.js` hide-when-empty branch is left as-is; it simply never fires for `event_type` now.

## Fix #2 — disable filters while loading (commit `e0bc1f3`)
Toggling a filter while a fetch was in flight could interleave with the response and corrupt the selection.

- `EventList.js` now threads its existing `loading` flag into `<EventFilters disabled={loading} />` (local prop pass-through, no new global state).
- `EventFilters.js` accepts `disabled` and gates `onToggle` / `onClear`; the pills, option buttons, and clear button get the native `disabled` attribute, the container gets `aria-busy` + an `is-disabled` class, and `public.css` greys the bar (`opacity: .55`, `cursor: not-allowed`).
- **Before:** during a fetch you could open panels and toggle options, racing the in-flight request. **After:** while `loading` is true the bar is greyed and inert — panels won't open and option/clear clicks are no-ops — then becomes interactive again when the response lands. This disabled state is kept separate from the hide-when-empty logic.

## Verification
- `npm run build` compiles both bundles cleanly.
- PHP change is in `includes/Rest/EventsController.php`; the only `composer lint` findings are pre-existing style nits in `mayo-events-manager.php` (unrelated to this PR).
- Changelog updated in `readme.txt` (one entry per fix, no version bump).