### PR TITLE
Enforce external source category filter on imported events [#292]

### DIFF
--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1496,6 +1496,24 @@ class EventsController {
                 'service_bodies' => $service_bodies,
             ];
 
+            // Enforce the source's category filter locally. The param is also
+            // forwarded to the remote, but a remote on an older Mayo, a non-Mayo
+            // feed, or one using different category slugs may ignore it and
+            // return everything; re-applying it here makes the configured
+            // category authoritative. Empty filter = no constraint (no leak, no
+            // default category injected).
+            $effective_categories = self::effective_source_filter($source, 'categories');
+            if ($effective_categories !== '') {
+                $cat_relation = self::effective_source_filter($source, 'category_relation') ?: 'OR';
+                $events = array_values(array_filter($events, function ($event) use ($effective_categories, $cat_relation) {
+                    return TaxonomyQuery::event_matches_category_filter(
+                        $event['categories'] ?? [],
+                        $effective_categories,
+                        $cat_relation
+                    );
+                }));
+            }
+
             // Tag events with source info
             foreach ($events as &$event) {
                 $event['source_id'] = $sid;
@@ -1527,6 +1545,27 @@ class EventsController {
     }
 
     /**
+     * Resolve the effective value for an external-feed filter facet.
+     *
+     * The visitor's live $_GET selection wins over the source's admin-configured
+     * default; the source default applies only when the visitor has not set that
+     * filter. Shared by build_external_filter_params (what we ask the remote for)
+     * and the local post-fetch enforcement (what we actually keep) so the two
+     * never drift apart.
+     *
+     * @param array  $source Source configuration entry
+     * @param string $key    Facet key (e.g. 'categories', 'category_relation')
+     * @return string Effective value ('' when neither visitor nor source set it)
+     */
+    private static function effective_source_filter($source, $key) {
+        $user_value = isset($_GET[$key]) ? sanitize_text_field(wp_unslash($_GET[$key])) : '';
+        if ($user_value !== '') {
+            return $user_value;
+        }
+        return (string) ($source[$key] ?? '');
+    }
+
+    /**
      * Build the filter params for an external feed request.
      *
      * The visitor's live $_GET selection wins over the source's admin-configured
@@ -1538,23 +1577,11 @@ class EventsController {
      * @return array Associative array of filter params (only set keys are returned)
      */
     private static function build_external_filter_params($source) {
-        $get_param = function ($key) {
-            return isset($_GET[$key]) ? sanitize_text_field(wp_unslash($_GET[$key])) : '';
-        };
-
-        $defaults = [
-            'event_type'        => $source['event_type'] ?? '',
-            'service_body'      => $source['service_body'] ?? '',
-            'relation'          => $source['relation'] ?? '',
-            'categories'        => $source['categories'] ?? '',
-            'category_relation' => $source['category_relation'] ?? '',
-            'tags'              => $source['tags'] ?? '',
-        ];
+        $keys = ['event_type', 'service_body', 'relation', 'categories', 'category_relation', 'tags'];
 
         $params = [];
-        foreach ($defaults as $key => $source_value) {
-            $user_value = $get_param($key);
-            $value = $user_value !== '' ? $user_value : (string) $source_value;
+        foreach ($keys as $key) {
+            $value = self::effective_source_filter($source, $key);
             if ($value !== '') {
                 $params[$key] = $value;
             }
@@ -1631,6 +1658,19 @@ class EventsController {
                 'name' => $source['name'] ?? parse_url($source['url'], PHP_URL_HOST),
                 'service_bodies' => $service_bodies
             ];
+
+            // Enforce the source's category filter locally (see fetch_all_external_events).
+            $effective_categories = self::effective_source_filter($source, 'categories');
+            if ($effective_categories !== '') {
+                $cat_relation = self::effective_source_filter($source, 'category_relation') ?: 'OR';
+                $events = array_values(array_filter($events, function ($event) use ($effective_categories, $cat_relation) {
+                    return TaxonomyQuery::event_matches_category_filter(
+                        $event['categories'] ?? [],
+                        $effective_categories,
+                        $cat_relation
+                    );
+                }));
+            }
 
             // Attach source info to each event (service bodies are in the sources array)
             foreach ($events as &$event) {

--- a/includes/Rest/Helpers/TaxonomyQuery.php
+++ b/includes/Rest/Helpers/TaxonomyQuery.php
@@ -139,6 +139,86 @@ class TaxonomyQuery {
     }
 
     /**
+     * Check whether an event's category payload satisfies a filter string.
+     *
+     * Used as a local backstop when consuming external feeds: a remote that
+     * runs an older Mayo, isn't Mayo, or uses different category slugs may
+     * silently ignore the forwarded `categories` param and return everything
+     * (build_taxonomy_args adds no tax_query when no slug resolves). This
+     * re-applies the filter on the data we actually received so the source's
+     * configured category is authoritative regardless of remote behavior.
+     *
+     * Matching mirrors parse_taxonomy_filter semantics (comma-separated,
+     * '-' prefix excludes) but compares against the event payload's category
+     * slug AND name, case-insensitively, since the UI accepts either form.
+     *
+     * @param array  $event_categories Event category objects (each may have 'slug'/'name'), as returned by get_terms()
+     * @param string $filter           Comma-separated category slugs/names (prefix with '-' to exclude)
+     * @param string $relation         'AND' or 'OR' - how to match multiple includes (default OR)
+     * @return bool True if the event passes the filter (empty filter passes everything)
+     */
+    public static function event_matches_category_filter($event_categories, $filter, $relation = 'OR') {
+        $parsed = self::parse_taxonomy_filter($filter);
+
+        // No constraint -> everything passes. Crucially this means a source with
+        // no configured category does not filter (and never injects a default).
+        if ($parsed['include'] === '' && $parsed['exclude'] === '') {
+            return true;
+        }
+
+        // Build a case-insensitive lookup of the event's category slugs + names.
+        $event_terms = [];
+        if (is_array($event_categories)) {
+            foreach ($event_categories as $cat) {
+                if (!is_array($cat)) {
+                    continue;
+                }
+                if (isset($cat['slug']) && $cat['slug'] !== '') {
+                    $event_terms[strtolower($cat['slug'])] = true;
+                }
+                if (isset($cat['name']) && $cat['name'] !== '') {
+                    $event_terms[strtolower($cat['name'])] = true;
+                }
+            }
+        }
+
+        // Exclusion wins: if the event carries any excluded term, drop it.
+        if ($parsed['exclude'] !== '') {
+            foreach (array_map('trim', explode(',', $parsed['exclude'])) as $token) {
+                if ($token !== '' && isset($event_terms[strtolower($token)])) {
+                    return false;
+                }
+            }
+        }
+
+        // Inclusion: OR = at least one match, AND = all must match.
+        if ($parsed['include'] !== '') {
+            $include_tokens = array_filter(array_map('trim', explode(',', $parsed['include'])), function ($t) {
+                return $t !== '';
+            });
+
+            if (!empty($include_tokens)) {
+                $is_and = strtoupper($relation) === 'AND';
+                $matched_any = false;
+                foreach ($include_tokens as $token) {
+                    $has = isset($event_terms[strtolower($token)]);
+                    if ($is_and && !$has) {
+                        return false;
+                    }
+                    if ($has) {
+                        $matched_any = true;
+                    }
+                }
+                if (!$is_and && !$matched_any) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get terms for a post
      *
      * @param \WP_Post|int $post Post object or post ID

--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.9.1
+ * Version: 1.9.2
  * Requires at least: 6.7
  * Tested up to: 7.0
  * Author: bmlt-enabled
@@ -24,7 +24,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.9.1');
+define('MAYO_VERSION', '1.9.2');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.1 =
+* Fixed external feed sources ignoring their configured category filter: a category set on an external source now actually narrows which events are imported, even when the remote site runs an older version, isn't a Mayo site, or uses different category slugs. Previously an unmatched category was silently dropped and the source returned all of its events. Sources with no category configured are unaffected. [#292]
 * Fixed the event list filter bar omitting event types that had no currently scheduled events; the Event Type filter now always offers the full set (Service, Activity, Celebration) regardless of what's on the calendar. [#290]
 * Fixed a race where toggling filters while the event list was still loading could leave the selection in an inconsistent state; the filter bar is now disabled (greyed out) while a request is in flight. [#290]
 * Added an optional private phone-number contact field to the event and announcement submission forms. It is hidden by default and enabled per-form with the new `show_phone` shortcode option; add `phone` to `additional_required_fields` to make it mandatory. Like the contact email, the number is stored privately for organizers and is never displayed publicly. [#288]

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -187,8 +187,10 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
-= 1.9.1 =
+= 1.9.2 =
 * Fixed external feed sources ignoring their configured category filter: a category set on an external source now actually narrows which events are imported, even when the remote site runs an older version, isn't a Mayo site, or uses different category slugs. Previously an unmatched category was silently dropped and the source returned all of its events. Sources with no category configured are unaffected. [#292]
+
+= 1.9.1 =
 * Fixed the event list filter bar omitting event types that had no currently scheduled events; the Event Type filter now always offers the full set (Service, Activity, Celebration) regardless of what's on the calendar. [#290]
 * Fixed a race where toggling filters while the event list was still loading could leave the selection in an inconsistent state; the filter bar is now disabled (greyed out) while a request is in flight. [#290]
 * Added an optional private phone-number contact field to the event and announcement submission forms. It is hidden by default and enabled per-form with the new `show_phone` shortcode option; add `phone` to `additional_required_fields` to make it mandatory. Like the contact email, the number is stored privately for organizers and is never displayed publicly. [#288]

--- a/tests/Unit/Rest/EventsControllerTest.php
+++ b/tests/Unit/Rest/EventsControllerTest.php
@@ -1919,4 +1919,45 @@ class EventsControllerTest extends TestCase {
         $data = $response->get_data();
         $this->assertCount(0, $data['events'], 'Event should be hidden when current time is after event ends');
     }
+
+    /**
+     * Invoke the private static effective_source_filter for testing.
+     */
+    private function effectiveSourceFilter(array $source, string $key): string {
+        $method = new \ReflectionMethod(EventsController::class, 'effective_source_filter');
+        $method->setAccessible(true);
+        return $method->invoke(null, $source, $key);
+    }
+
+    /**
+     * The source default is used for an external feed facet when the visitor
+     * has not set that filter via $_GET. Same value drives both the forwarded
+     * param and the local post-fetch enforcement, so they cannot drift.
+     */
+    public function testEffectiveSourceFilterUsesSourceDefault(): void {
+        $_GET = [];
+        $source = ['categories' => 'conventions'];
+
+        $this->assertSame('conventions', $this->effectiveSourceFilter($source, 'categories'));
+    }
+
+    /**
+     * The visitor's live $_GET selection overrides the source default.
+     */
+    public function testEffectiveSourceFilterVisitorOverridesSource(): void {
+        $_GET = ['categories' => 'workshops'];
+        $source = ['categories' => 'conventions'];
+
+        $this->assertSame('workshops', $this->effectiveSourceFilter($source, 'categories'));
+    }
+
+    /**
+     * No visitor value and no source default resolves to an empty string,
+     * which the enforcement treats as "no constraint" (no leak, no default).
+     */
+    public function testEffectiveSourceFilterEmptyWhenUnset(): void {
+        $_GET = [];
+
+        $this->assertSame('', $this->effectiveSourceFilter([], 'categories'));
+    }
 }

--- a/tests/Unit/Rest/Helpers/TaxonomyQueryTest.php
+++ b/tests/Unit/Rest/Helpers/TaxonomyQueryTest.php
@@ -287,4 +287,82 @@ class TaxonomyQueryTest extends TestCase {
 
         $this->assertEquals('News & Events', $result[0]['name']);
     }
+
+    /**
+     * Helper: a minimal event category payload as produced by get_terms().
+     */
+    private function cat(string $slug, string $name): array {
+        return ['id' => 1, 'name' => $name, 'slug' => $slug, 'link' => 'https://example.com'];
+    }
+
+    /**
+     * An empty filter is no constraint: every event passes (no leak, no default injected).
+     */
+    public function testEventMatchesCategoryFilterEmptyFilterPassesEverything(): void {
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter([], ''));
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter(
+            [$this->cat('conventions', 'Conventions')],
+            ''
+        ));
+    }
+
+    /**
+     * Source with a category keeps only events that carry it; others are dropped.
+     */
+    public function testEventMatchesCategoryFilterNarrowsBySlug(): void {
+        $matching = [$this->cat('conventions', 'Conventions')];
+        $other    = [$this->cat('workshops', 'Workshops')];
+
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($matching, 'conventions'));
+        $this->assertFalse(TaxonomyQuery::event_matches_category_filter($other, 'conventions'));
+    }
+
+    /**
+     * An event with no categories never satisfies a non-empty include filter.
+     */
+    public function testEventMatchesCategoryFilterEventWithNoCategoriesDropped(): void {
+        $this->assertFalse(TaxonomyQuery::event_matches_category_filter([], 'conventions'));
+    }
+
+    /**
+     * Matching is case-insensitive and works against the name as well as the slug,
+     * so a UI value of "Conventions" still matches slug "conventions".
+     */
+    public function testEventMatchesCategoryFilterCaseInsensitiveNameAndSlug(): void {
+        $event = [$this->cat('conventions', 'Conventions')];
+
+        // UI typed the display name with different casing.
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($event, 'Conventions'));
+        // UI typed the slug with different casing.
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($event, 'CONVENTIONS'));
+        // Match against the name field even when the slug differs.
+        $nameOnly = [$this->cat('cat-7', 'Conventions')];
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($nameOnly, 'conventions'));
+    }
+
+    /**
+     * Exclude semantics: a '-' prefixed token drops events carrying that category.
+     */
+    public function testEventMatchesCategoryFilterExcludeDropsMatch(): void {
+        $event = [$this->cat('conventions', 'Conventions')];
+
+        $this->assertFalse(TaxonomyQuery::event_matches_category_filter($event, '-conventions'));
+        // An event without the excluded category passes.
+        $other = [$this->cat('workshops', 'Workshops')];
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($other, '-conventions'));
+    }
+
+    /**
+     * OR (default) = any include matches; AND = all includes must be present.
+     */
+    public function testEventMatchesCategoryFilterRelation(): void {
+        $oneOfTwo = [$this->cat('conventions', 'Conventions')];
+        $bothCats = [$this->cat('conventions', 'Conventions'), $this->cat('workshops', 'Workshops')];
+
+        // OR: having one of the two is enough.
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($oneOfTwo, 'conventions,workshops', 'OR'));
+        // AND: must carry both.
+        $this->assertFalse(TaxonomyQuery::event_matches_category_filter($oneOfTwo, 'conventions,workshops', 'AND'));
+        $this->assertTrue(TaxonomyQuery::event_matches_category_filter($bothCats, 'conventions,workshops', 'AND'));
+    }
 }


### PR DESCRIPTION
Closes #292

## Diagnosis — it's the import/filter path (branch **b**), not persistence or schema

External-source events are **fetched live and merged**, never stored as posts (`EventsController::fetch_all_external_events`). So this is about *which* events get pulled, and there is no taxonomy term to set on a transient event.

- **(a) Persistence — works.** `categories` is bound in the source form (`assets/js/src/components/admin/Settings.js:581-587`, help text *"Filter by categories"*) and whitelisted + saved into the `mayo_external_sources` option (`includes/Rest/SettingsController.php:248`, saved `:144-145`).
- **(c) Schema — works.** The option-array `categories` slot exists.
- **(b) Filter enforcement — broken (remote-only, silent leak).** The source `categories` is forwarded as a query param to the remote feed (`build_external_filter_params`, added in #279). The remote resolves it **by slug** via `TaxonomyQuery::build_taxonomy_args` → `get_term_by('slug', …, 'category')` (`includes/Rest/Helpers/TaxonomyQuery.php:65-85`). **When no term resolves, no `tax_query` is added and the remote returns every event.** The local consumer then merged whatever came back **without re-checking the category** (`EventsController.php:~1490` only stamped `source` info). So an older Mayo, a non-Mayo feed, or a different slug → the configured category is silently ignored and the source dumps its entire catalog.

This matches the reported symptom exactly: *set Categories = "conventions" on a source → it pulls everything.* (A genuinely broken save would yield **no** events, not all of them.)

> Note on the ticket AC wording: it was framed as *assignment* ("imported events carry that category / post meta or taxonomy term"). The reporter clarified the real expectation is *filtering*, and since external events are never stored as posts there is nothing to tag — so the fix makes the existing **category filter** authoritative rather than assigning a category to transient events.

## Fix

Keep forwarding the param to the remote (smaller payloads when honored) **and** add a local backstop:

1. **`TaxonomyQuery::event_matches_category_filter()`** — pure helper that re-checks an event's `categories` payload against the filter, reusing `parse_taxonomy_filter` (comma / `-`exclude) and matching **case-insensitively against both slug and name** (so a UI value of "Conventions" matches slug `conventions`). Empty filter → passes everything.
2. **`EventsController::effective_source_filter()`** — shared precedence helper (visitor `$_GET` wins over the source default), used by both `build_external_filter_params` and the new enforcement so the forwarded param and local check can't drift.
3. **Local enforcement** in both `fetch_all_external_events` (live path) and `fetch_external_events`: after fetching a source's events, drop any whose category payload doesn't satisfy the effective filter.

## Acceptance criteria

- ✅ **Category persisted on the source** — already was (`SettingsController.php:248`); confirmed during diagnosis.
- ✅ **Imported events honor the configured category** — enforced locally regardless of remote behavior.
- ✅ **No retroactive re-tag** (AC #3) — external events are transient; nothing historical is touched, and this filters rather than tags.
- ✅ **No default leak** (AC #4) — a source with no category yields an empty filter, which passes events through with their own categories; **no default category is injected** (covered by `testEventMatchesCategoryFilterEmptyFilterPassesEverything` and `testEffectiveSourceFilterEmptyWhenUnset`).

## Tests

`composer test` → **537 passing**. New coverage:
- `TaxonomyQueryTest`: source-with-category narrows by slug; source-without-category passes all (no leak/no default); case-insensitive slug+name match; `-`exclude; OR/AND relation.
- `EventsControllerTest`: `effective_source_filter` precedence — source default, visitor `$_GET` override, and empty-when-unset.

`composer lint` (root files) passes; no new phpcs violations in the changed code.

## Scope note

The sibling `tags` source filter has the identical latent leak (same `TaxonomyQuery` no-op). This PR fixes **categories only** (the reported facet); tags can follow the same shape if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)