### PR TITLE
Support excluding event types from the event list (#296)

### DIFF
--- a/assets/js/src/components/admin/ApiDocs.js
+++ b/assets/js/src/components/admin/ApiDocs.js
@@ -82,7 +82,7 @@ const ApiDocs = () => {
                             <td><code>event_type</code></td>
                             <td>string</td>
                             <td>empty</td>
-                            <td>Filter by event type (e.g., <code>Service</code>, <code>Activity</code>)</td>
+                            <td>Filter by event type. Comma-separate to include several (<code>Service,Activity</code>), or prefix with <code>-</code> to exclude (<code>-Celebration</code>).</td>
                         </tr>
                         <tr>
                             <td><code>service_body</code></td>

--- a/assets/js/src/components/admin/ShortcodesDocs.js
+++ b/assets/js/src/components/admin/ShortcodesDocs.js
@@ -70,10 +70,10 @@ const ShortcodesDocs = () => {
                         </tr>
                         <tr>
                             <td>event_type</td>
-                            <td>Filter by event type</td>
+                            <td>Filter by event type. Comma-separate to include several, or prefix a type with "-" to exclude it.</td>
                             <td>empty (all types)</td>
-                            <td>Service, Activity</td>
-                            <td>Yes (only one event type at a time)</td>
+                            <td>Service, Activity, Celebration (e.g. "Service,Activity" or "-Celebration")</td>
+                            <td>Yes</td>
                         </tr>
                         <tr>
                             <td>time_format</td>
@@ -144,9 +144,9 @@ const ShortcodesDocs = () => {
                 <h3>Example with Parameters</h3>
                 <pre><code>[mayo_event_list time_format="24hour" per_page="5" categories="meetings,workshops" tags="featured" event_type="Service" service_body="1,2,3" source_ids="local,source_123" archive="false" order="ASC" timezone="America/New_York" view="calendar"]</code></pre>
 
-                <h3>Example with Category/Tag Exclusions</h3>
-                <pre><code>[mayo_event_list categories="-announcements,-alerts" tags="-archived"]</code></pre>
-                <p><em>Shows all events except those with the "announcements" or "alerts" categories, and excludes the "archived" tag.</em></p>
+                <h3>Example with Category/Tag/Event Type Exclusions</h3>
+                <pre><code>[mayo_event_list categories="-announcements,-alerts" tags="-archived" event_type="-Celebration"]</code></pre>
+                <p><em>Shows all events except those with the "announcements" or "alerts" categories, excludes the "archived" tag, and hides "Celebration" events (leaving Service and Activity).</em></p>
 
                 <h3>Example with Querystring Overrides</h3>
                 <pre><code>https://example.com/events?status=pending&categories=meetings,workshops&event_type=Service&service_body="1,2,3"&source_ids=local,source_123&archive=true&order=DESC&timezone=America/New_York&infinite_scroll=false&per_page=20&view=calendar</code></pre>

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -103,7 +103,7 @@ class Frontend {
             'categories' => '',  // Comma-separated category slugs
             'category_relation' => 'OR',  // AND or OR - how to match multiple categories
             'tags' => '',       // Comma-separated tag slugs
-            'event_type' => '',  // Single event type (Service, Activity, Celebration)
+            'event_type' => '',  // Event type filter: a single type (Service/Activity/Celebration), a comma-separated include list ("Service,Activity"), or a "-" prefix to exclude ("-Celebration")
             'status' => 'publish',  // Single event status (publish, pending)
             'service_body' => '',  // Comma-separated service body IDs
             'source_ids' => '',  // Comma-separated source IDs

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1074,21 +1074,8 @@ class EventsController {
             ]
         ];
 
-        if (!empty($eventType)) {
-            if (str_contains($eventType, ',')) {
-                $event_types = array_map('trim', explode(',', $eventType));
-                $recurring_meta_query[] = [
-                    'key' => 'event_type',
-                    'value' => $event_types,
-                    'compare' => 'IN'
-                ];
-            } else {
-                $recurring_meta_query[] = [
-                    'key' => 'event_type',
-                    'value' => $eventType,
-                    'compare' => '='
-                ];
-            }
+        foreach (self::build_event_type_meta_query($eventType) as $row) {
+            $recurring_meta_query[] = $row;
         }
 
         if (!empty($serviceBody)) {
@@ -1230,6 +1217,53 @@ class EventsController {
     }
 
     /**
+     * Build the meta_query row(s) for an event_type filter string.
+     *
+     * Supports three token forms (comma-separated, in any combination):
+     *  - a bare type ("Service")            → include via '=' / 'IN'
+     *  - a dash-prefixed type ("-Celebration") → exclude via 'NOT IN'
+     * Include and exclude tokens may be mixed ("Service,-Celebration"); the
+     * resulting rows are AND-ed together by the caller's meta_query relation.
+     *
+     * @param string $eventType Raw event_type filter value.
+     * @return array List of meta_query rows (0, 1, or 2 entries).
+     */
+    private static function build_event_type_meta_query($eventType) {
+        $eventType = trim((string) $eventType);
+        if ($eventType === '') {
+            return [];
+        }
+
+        $includes = [];
+        $excludes = [];
+        foreach (array_map('trim', explode(',', $eventType)) as $token) {
+            if ($token === '') {
+                continue;
+            }
+            if (str_starts_with($token, '-')) {
+                $name = trim(substr($token, 1));
+                if ($name !== '') {
+                    $excludes[] = $name;
+                }
+            } else {
+                $includes[] = $token;
+            }
+        }
+
+        $rows = [];
+        if (!empty($includes)) {
+            $rows[] = count($includes) === 1
+                ? ['key' => 'event_type', 'value' => $includes[0], 'compare' => '=']
+                : ['key' => 'event_type', 'value' => $includes, 'compare' => 'IN'];
+        }
+        if (!empty($excludes)) {
+            $rows[] = ['key' => 'event_type', 'value' => $excludes, 'compare' => 'NOT IN'];
+        }
+
+        return $rows;
+    }
+
+    /**
      * Query events with given parameters
      *
      * @param string $status Post status
@@ -1245,21 +1279,8 @@ class EventsController {
     private static function query_events($status, $eventType, $serviceBody, $relation, $categories, $categoryRelation, $tags, $min_date = null) {
         $meta_query = [];
 
-        if (!empty($eventType)) {
-            if (str_contains($eventType, ',')) {
-                $event_types = array_map('trim', explode(',', $eventType));
-                $meta_query[] = [
-                    'key' => 'event_type',
-                    'value' => $event_types,
-                    'compare' => 'IN'
-                ];
-            } else {
-                $meta_query[] = [
-                    'key' => 'event_type',
-                    'value' => $eventType,
-                    'compare' => '='
-                ];
-            }
+        foreach (self::build_event_type_meta_query($eventType) as $row) {
+            $meta_query[] = $row;
         }
 
         if (!empty($serviceBody)) {

--- a/readme.txt
+++ b/readme.txt
@@ -189,6 +189,7 @@ This project is licensed under the GPL v2 or later.
 
 = 1.9.2 =
 * Fixed the calendar view showing an unnecessary scrollbar on every day cell. Day cells now only scroll internally when they actually contain more events than fit. [#298]
+* Added event-type exclusion to the event list: prefix a type with "-" to hide it (e.g. `event_type="-Celebration"` shows Service and Activity events), or list the types to keep (`event_type="Service,Activity"`). Exclusion is future-proof — any event types added later stay visible automatically. [#296]
 * Fixed external feed sources ignoring their configured category filter: a category set on an external source now actually narrows which events are imported, even when the remote site runs an older version, isn't a Mayo site, or uses different category slugs. Previously an unmatched category was silently dropped and the source returned all of its events. Sources with no category configured are unaffected. [#292]
 
 = 1.9.1 =

--- a/tests/Unit/Rest/EventsControllerTest.php
+++ b/tests/Unit/Rest/EventsControllerTest.php
@@ -1024,6 +1024,84 @@ class EventsControllerTest extends TestCase {
     }
 
     /**
+     * Collect every event_type meta_query row passed to get_posts during a
+     * get_events() call. get_events queries twice (recurring + non-recurring),
+     * so a given row may appear more than once — assertions look for presence,
+     * not counts.
+     *
+     * @return array<int, array> List of event_type meta_query rows.
+     */
+    private function captureEventTypeMetaRows(): array {
+        $rows = [];
+        Functions\when('get_posts')->alias(function ($args) use (&$rows) {
+            if (!empty($args['meta_query']) && is_array($args['meta_query'])) {
+                foreach ($args['meta_query'] as $key => $row) {
+                    if (is_array($row) && isset($row['key']) && $row['key'] === 'event_type') {
+                        $rows[] = $row;
+                    }
+                }
+            }
+            return [];
+        });
+        Functions\when('get_site_url')->justReturn('https://example.com');
+
+        EventsController::get_events();
+
+        return $rows;
+    }
+
+    /**
+     * A dash-prefixed event_type excludes that type via NOT IN (issue #296).
+     */
+    public function testGetEventsExcludesEventTypeWithDashPrefix(): void {
+        $_GET = ['event_type' => '-Celebration'];
+
+        $rows = $this->captureEventTypeMetaRows();
+
+        $this->assertNotEmpty($rows, 'Expected an event_type meta_query row');
+        foreach ($rows as $row) {
+            $this->assertSame('NOT IN', $row['compare']);
+            $this->assertSame(['Celebration'], $row['value']);
+        }
+    }
+
+    /**
+     * Comma-separated event types are matched with IN (positive listing).
+     */
+    public function testGetEventsIncludesCommaSeparatedEventTypes(): void {
+        $_GET = ['event_type' => 'Service,Activity'];
+
+        $rows = $this->captureEventTypeMetaRows();
+
+        $this->assertNotEmpty($rows, 'Expected an event_type meta_query row');
+        foreach ($rows as $row) {
+            $this->assertSame('IN', $row['compare']);
+            $this->assertSame(['Service', 'Activity'], $row['value']);
+        }
+    }
+
+    /**
+     * Mixed include + exclude tokens produce both an include and a NOT IN row.
+     */
+    public function testGetEventsMixedIncludeAndExcludeEventTypes(): void {
+        $_GET = ['event_type' => 'Service,-Celebration'];
+
+        $rows = $this->captureEventTypeMetaRows();
+
+        $includeRows = array_filter($rows, fn($row) => $row['compare'] === '=');
+        $excludeRows = array_filter($rows, fn($row) => $row['compare'] === 'NOT IN');
+
+        $this->assertNotEmpty($includeRows, 'Expected an include (=) row for Service');
+        $this->assertNotEmpty($excludeRows, 'Expected a NOT IN row for Celebration');
+        foreach ($includeRows as $row) {
+            $this->assertSame('Service', $row['value']);
+        }
+        foreach ($excludeRows as $row) {
+            $this->assertSame(['Celebration'], $row['value']);
+        }
+    }
+
+    /**
      * Test get_events with service_body filter
      */
     public function testGetEventsWithServiceBodyFilter(): void {


### PR DESCRIPTION
Closes #296

## Problem

The `[mayo_event_list]` `event_type` filter only matched **positively** — a single value (`=`) or a comma-separated list (`IN`). When the reporter set `event_type="-Celebrations"` to hide Celebrations, the `-Celebrations` string was treated as a literal event-type value and matched nothing.

This was a **feature gap**, not a bug in existing behavior: `event_type="Service,Activity"` already worked as a positive listing.

## Change

Add `-` prefix **exclusion** support, mirroring the convention already used for categories/tags (`TaxonomyQuery`):

- `event_type="-Celebration"` → hide Celebration (`NOT IN`), leaving Service + Activity. Future-proof: new event types stay visible automatically.
- `event_type="Service,Activity"` → include list (`IN`), unchanged.
- Mixed (`event_type="Service,-Celebration"`) → include **and** exclude rows, AND-ed together.

The previously-duplicated `event_type` meta_query logic (in both `query_events()` and the recurring-events builder) is consolidated into one `build_event_type_meta_query()` helper.

No facet/JS-logic change was needed: a shortcode `event_type` already "locks" the Event Type dropdown, so `-Celebration` also removes it from the interactive picker.

## Tests

Added unit tests capturing the `get_posts` `meta_query` for the exclude, comma-separated include, and mixed cases. Full suite green: **540 tests, 1217 assertions**.

## Docs

- `readme.txt` changelog (under the unreleased 1.9.2 section — no version bump)
- In-app Shortcode & API docs (`ShortcodesDocs.js`, `ApiDocs.js`) and the `Frontend.php` inline comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJTPYfHdWbE8XjTFJgM3Qo