### PR TITLE
Remove per-day scrollbars from calendar view

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -501,7 +501,7 @@
     border-right: 1px solid #ddd;
     border-bottom: 1px solid #ddd;
     position: relative;
-    overflow-y: auto;
+    overflow-y: hidden;
 }
 
 .mayo-calendar-day.empty {

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.2 =
+* Fixed the calendar view showing an unnecessary scrollbar on every day cell. Day cells now only scroll internally when they actually contain more events than fit. [#298]
 * Fixed external feed sources ignoring their configured category filter: a category set on an external source now actually narrows which events are imported, even when the remote site runs an older version, isn't a Mayo site, or uses different category slugs. Previously an unmatched category was silently dropped and the source returned all of its events. Sources with no category configured are unaffected. [#292]
 
 = 1.9.1 =


### PR DESCRIPTION
Closes #298

## Problem
Every day cell in the public calendar view showed a vertical scrollbar whether or not it contained events. Scrollbars should only appear when a day holds more events than fit.

## Root cause
Two nested scroll containers both declared `overflow-y: auto`:
- `.mayo-calendar-day` — the outer day cell
- `.mayo-calendar-events` — the inner event list (the intended scroll region: `height: calc(100% - 30px)`, `overflow-y: auto`)

The outer cell's scrollbar was redundant and appeared even on empty days, because the sticky `.mayo-calendar-date` header uses negative margins (`margin: -8px -8px 8px -8px`) that push content just past the cell's padding box and trip `overflow-y: auto`.

## Fix
Set `.mayo-calendar-day` to `overflow-y: hidden`. The inner `.mayo-calendar-events` container is left untouched and remains the single scroll region, so days with too many events still scroll internally while empty/normal days no longer show a spurious cell scrollbar.

CSS-only change; `public.css` is enqueued directly, so no build step is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sxRztbnXZaux4apj6K6Hy