### PR TITLE
Default event form dates to today with end matching start

### DIFF
--- a/assets/js/src/components/public/EventForm.js
+++ b/assets/js/src/components/public/EventForm.js
@@ -38,6 +38,15 @@ const EventForm = () => {
         textarea.innerHTML = text;
         return textarea.value;
     };
+
+    // Today's date as YYYY-MM-DD in the browser's local time (for date input defaults)
+    const getTodayLocalDate = () => {
+        const d = new Date();
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    };
     
     // Define default required fields that cannot be overridden
     const defaultRequiredFields = [
@@ -96,8 +105,8 @@ const EventForm = () => {
     const [formData, setFormData] = useState({
         event_name: '',
         event_type: '',
-        event_start_date: '',
-        event_end_date: '',
+        event_start_date: getTodayLocalDate(),
+        event_end_date: getTodayLocalDate(),
         event_start_time: '',
         event_end_time: '',
         timezone: getUserTimezone(),
@@ -311,8 +320,8 @@ const EventForm = () => {
                 setFormData({
                     event_name: '',
                     event_type: '',
-                    event_start_date: '',
-                    event_end_date: '',
+                    event_start_date: getTodayLocalDate(),
+                    event_end_date: getTodayLocalDate(),
                     event_start_time: '',
                     event_end_time: '',
                     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -419,6 +428,19 @@ const EventForm = () => {
             };
             reader.readAsDataURL(file);
         } else {
+            if (name === 'event_start_date') {
+                setFormData(prev => {
+                    // Keep end date matching start unless the user has set a different end date
+                    const shouldSyncEnd =
+                        !prev.event_end_date || prev.event_end_date === prev.event_start_date;
+                    return {
+                        ...prev,
+                        event_start_date: value,
+                        event_end_date: shouldSyncEnd ? value : prev.event_end_date
+                    };
+                });
+                return;
+            }
             setFormData(prev => ({
                 ...prev,
                 [name]: value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mayo",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mayo",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-react": "^7.26.3",

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.2 =
+* Added date defaults to the event submission form: the Start Date now pre-fills to today's date and the End Date automatically matches the Start Date (until you set a different end date), so single-day events need only one date entry. [#301]
 * Added a JavaScript example (docs/rest-api-javascript-example.md) showing how to pull events from the REST API filtered by service body and tag, resolving the human-readable names to the id/slug the API expects via the facets endpoint. [#302]
 * Fixed the calendar view showing an unnecessary scrollbar on every day cell. Day cells now only scroll internally when they actually contain more events than fit. [#298]
 * Added event-type exclusion to the event list: prefix a type with "-" to hide it (e.g. `event_type="-Celebration"` shows Service and Activity events), or list the types to keep (`event_type="Service,Activity"`). Exclusion is future-proof — any event types added later stay visible automatically. [#296]


### PR DESCRIPTION
Closes #301

## What & why

The public event submission form (`[mayo_event_form]`) started with blank Start Date and End Date fields. Issue #301 asked to default the End Date to the Start Date and to default the start year to the current year.

## Changes (`assets/js/src/components/public/EventForm.js`)

- **Start Date pre-fills to today's date** (delivers the current year; a native `<input type="date">` can't default only the year). Uses a local-time `getTodayLocalDate()` helper — not `toISOString()` — to avoid a UTC off-by-one.
- **End Date matches Start Date** out of the box, and follows it whenever the Start Date changes — but only while the two are still equal, so a deliberately different multi-day end date is never clobbered.
- The post-submit form reset restores the same today-based defaults.

No PHP changed. `readme.txt` changelog updated under the unreleased `= 1.9.2 =` section (no version bump). The `package-lock.json` diff is just a stale `1.9.1 → 1.9.2` version sync with `package.json`.

## Testing

- `npm run build` compiles cleanly.
- Manual: on load both dates show today; changing Start Date updates End Date to match; after setting a later End Date, changing Start Date leaves it intact; submitting resets both to today.