### PR TITLE
Follow WordPress time format on submission forms [#300]

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -991,6 +991,27 @@
     flex: 1;
 }
 
+/* Time entry selects (Hour / Minute / AM-PM) rendered by TimeField. */
+.mayo-datetime-inputs .mayo-time-inputs {
+    flex: 1;
+}
+
+.mayo-time-inputs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.mayo-time-inputs select {
+    flex: 1;
+    min-width: 0;
+}
+
+.mayo-time-inputs .mayo-time-ampm,
+.mayo-time-inputs .mayo-time-sep {
+    flex: 0 0 auto;
+}
+
 @media (max-width: 600px) {
     .mayo-datetime-group {
         flex-direction: column;

--- a/assets/js/src/components/public/AnnouncementForm.js
+++ b/assets/js/src/components/public/AnnouncementForm.js
@@ -2,12 +2,17 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
+import TimeField from './TimeField';
 
 const AnnouncementForm = () => {
     // Get the settings from the data attribute
     const formElement = document.getElementById('mayo-announcement-form');
     const settingsKey = formElement?.dataset?.settings;
     const settings = window[settingsKey] || {};
+
+    // Time entry format for the Start/End fields: follows the WordPress "Time
+    // Format" setting by default (resolved server-side), overridable per shortcode.
+    const timeFormat = settings.timeFormat === '24hour' ? '24hour' : '12hour';
 
     // Get categories from shortcode parameter
     const categoriesParam = formElement?.dataset?.categories || '';
@@ -542,11 +547,11 @@ const AnnouncementForm = () => {
                                 <label htmlFor="start_time">
                                     {__('Start Time', 'mayo-events-manager')} {isFieldRequired('start_time') && '*'}
                                 </label>
-                                <input
-                                    type="time"
+                                <TimeField
                                     id="start_time"
                                     name="start_time"
                                     value={formData.start_time}
+                                    format={timeFormat}
                                     onChange={handleChange}
                                     required={isFieldRequired('start_time')}
                                 />
@@ -573,11 +578,11 @@ const AnnouncementForm = () => {
                                 <label htmlFor="end_time">
                                     {__('End Time', 'mayo-events-manager')} {isFieldRequired('end_time') && '*'}
                                 </label>
-                                <input
-                                    type="time"
+                                <TimeField
                                     id="end_time"
                                     name="end_time"
                                     value={formData.end_time}
+                                    format={timeFormat}
                                     onChange={handleChange}
                                     required={isFieldRequired('end_time')}
                                 />

--- a/assets/js/src/components/public/EventForm.js
+++ b/assets/js/src/components/public/EventForm.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEventProvider } from '../providers/EventProvider';
 import { apiFetch } from '../../util';
+import TimeField from './TimeField';
 import { getTimezonesByRegion, getUserTimezone } from '../../timezones';
 
 const EventForm = () => {
@@ -62,6 +63,10 @@ const EventForm = () => {
 
     // Whether the private phone contact field should be shown (via shortcode param)
     const showPhone = settings.showPhone === 'true';
+
+    // Time entry format for the Start/End fields: follows the WordPress "Time
+    // Format" setting by default (resolved server-side), overridable per shortcode.
+    const timeFormat = settings.timeFormat === '24hour' ? '24hour' : '12hour';
 
     // Filter service bodies based on configuration
     const getFilteredServiceBodies = () => {
@@ -609,11 +614,11 @@ const EventForm = () => {
                                 onChange={handleChange}
                                 required
                             />
-                            <input
-                                type="time"
+                            <TimeField
                                 id="event_start_time"
                                 name="event_start_time"
                                 value={formData.event_start_time}
+                                format={timeFormat}
                                 onChange={handleChange}
                                 required
                             />
@@ -630,11 +635,11 @@ const EventForm = () => {
                                 value={formData.event_end_date}
                                 onChange={handleChange}
                             />
-                            <input
-                                type="time"
+                            <TimeField
                                 id="event_end_time"
                                 name="event_end_time"
                                 value={formData.event_end_time}
+                                format={timeFormat}
                                 onChange={handleChange}
                                 required
                             />

--- a/assets/js/src/components/public/TimeField.js
+++ b/assets/js/src/components/public/TimeField.js
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+/**
+ * Break a canonical "HH:mm" value into the pieces each control needs.
+ * Returns empty pieces when the value is missing or malformed.
+ */
+const parseValue = (value, format) => {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(value || '');
+    if (!match) {
+        return { hour: '', minute: '', ampm: format === '12hour' ? 'AM' : '' };
+    }
+    const h24 = parseInt(match[1], 10);
+    const minute = match[2];
+    if (format === '12hour') {
+        return {
+            hour: String(h24 % 12 || 12),
+            minute,
+            ampm: h24 >= 12 ? 'PM' : 'AM',
+        };
+    }
+    return { hour: pad2(h24), minute, ampm: '' };
+};
+
+/**
+ * Recompose the control pieces into a canonical 24-hour "HH:mm" string.
+ * Returns '' while the selection is incomplete so callers can treat the
+ * field as empty (and required validation still fires).
+ */
+const composeValue = (hour, minute, ampm, format) => {
+    if (hour === '' || minute === '') return '';
+    let h24 = parseInt(hour, 10);
+    if (format === '12hour') {
+        if (!ampm) return '';
+        h24 = h24 % 12;
+        if (ampm === 'PM') h24 += 12;
+    }
+    return `${pad2(h24)}:${minute}`;
+};
+
+/**
+ * Time entry control that presents 12-hour (Hour / Minute / AM-PM) or
+ * 24-hour (Hour / Minute) selects based on `format`, while always emitting
+ * a canonical 24-hour "HH:mm" value via a synthetic change event so it drops
+ * into the existing name/value form handlers unchanged.
+ */
+const TimeField = ({ id, name, value, format, required, onChange }) => {
+    const is12 = format === '12hour';
+    const [pieces, setPieces] = useState(() => parseValue(value, format));
+
+    // Remember the last value we emitted so our own updates don't get
+    // clobbered by the sync effect below — only genuinely external changes
+    // (e.g. the form reset after a successful submit) should reparse.
+    const lastEmitted = useRef(value);
+
+    useEffect(() => {
+        if (value !== lastEmitted.current) {
+            lastEmitted.current = value;
+            setPieces(parseValue(value, format));
+        }
+    }, [value, format]);
+
+    const emit = (next) => {
+        setPieces(next);
+        const composed = composeValue(next.hour, next.minute, next.ampm, format);
+        lastEmitted.current = composed;
+        onChange({ target: { name, value: composed } });
+    };
+
+    const hours = is12
+        ? Array.from({ length: 12 }, (_, i) => String(i + 1))
+        : Array.from({ length: 24 }, (_, i) => pad2(i));
+    const minutes = Array.from({ length: 60 }, (_, i) => pad2(i));
+
+    return (
+        <div className="mayo-time-inputs" id={id}>
+            <select
+                className="mayo-time-hour"
+                name={`${name}_hour`}
+                aria-label={__('Hour', 'mayo-events-manager')}
+                value={pieces.hour}
+                required={required}
+                onChange={(e) => emit({ ...pieces, hour: e.target.value })}
+            >
+                <option value="">{__('Hour', 'mayo-events-manager')}</option>
+                {hours.map((h) => (
+                    <option key={h} value={h}>{h}</option>
+                ))}
+            </select>
+            <span className="mayo-time-sep">:</span>
+            <select
+                className="mayo-time-minute"
+                name={`${name}_minute`}
+                aria-label={__('Minute', 'mayo-events-manager')}
+                value={pieces.minute}
+                required={required}
+                onChange={(e) => emit({ ...pieces, minute: e.target.value })}
+            >
+                <option value="">{__('Min', 'mayo-events-manager')}</option>
+                {minutes.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                ))}
+            </select>
+            {is12 && (
+                <select
+                    className="mayo-time-ampm"
+                    name={`${name}_ampm`}
+                    aria-label={__('AM/PM', 'mayo-events-manager')}
+                    value={pieces.ampm}
+                    required={required}
+                    onChange={(e) => emit({ ...pieces, ampm: e.target.value })}
+                >
+                    <option value="AM">{__('AM', 'mayo-events-manager')}</option>
+                    <option value="PM">{__('PM', 'mayo-events-manager')}</option>
+                </select>
+            )}
+        </div>
+    );
+};
+
+export default TimeField;

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -50,13 +50,55 @@ class Frontend {
     }
 
 
+    /**
+     * Resolve a submission-form time format to '12hour' or '24hour'.
+     *
+     * Accepts an explicit '12hour'/'24hour' value, or (when empty) falls back
+     * to the site's WordPress "Time Format" setting so the form follows the
+     * WordPress date config. Any other value is treated as a PHP date-format
+     * string and inspected for a 12-hour token (a/A = am/pm, g/h = 12-hour hour),
+     * honoring backslash-escaped literals.
+     *
+     * @param string $value Explicit format, PHP time-format string, or ''.
+     * @return string '12hour' or '24hour'.
+     */
+    private static function resolve_time_format($value) {
+        if ('12hour' === $value || '24hour' === $value) {
+            return $value;
+        }
+
+        $format = '' === (string) $value ? (string) get_option('time_format') : (string) $value;
+
+        if ('' === $format) {
+            return '12hour';
+        }
+
+        $escaped = false;
+        foreach (str_split($format) as $char) {
+            if ($escaped) {
+                $escaped = false;
+                continue;
+            }
+            if ('\\' === $char) {
+                $escaped = true;
+                continue;
+            }
+            if (in_array($char, ['a', 'A', 'g', 'h'], true)) {
+                return '12hour';
+            }
+        }
+
+        return '24hour';
+    }
+
     public static function render_event_form($atts = []) {
         $defaults = [
             'additional_required_fields' => '',
             'categories' => '',
             'tags' => '',
             'default_service_bodies' => '',
-            'show_phone' => 'false'
+            'show_phone' => 'false',
+            'time_format' => '' // '12hour', '24hour', or '' to follow WordPress config
         ];
         $atts = shortcode_atts($defaults, $atts);
 
@@ -68,7 +110,8 @@ class Frontend {
         wp_localize_script('mayo-public', $settings_key, [
             'additionalRequiredFields' => $atts['additional_required_fields'],
             'defaultServiceBodies' => $atts['default_service_bodies'],
-            'showPhone' => $atts['show_phone']
+            'showPhone' => $atts['show_phone'],
+            'timeFormat' => self::resolve_time_format($atts['time_format'])
         ]);
         
         return sprintf(
@@ -205,7 +248,8 @@ class Frontend {
             'tags' => '',
             'default_service_bodies' => '',
             'show_flyer' => 'false',
-            'show_phone' => 'false'
+            'show_phone' => 'false',
+            'time_format' => '' // '12hour', '24hour', or '' to follow WordPress config
         ];
         $atts = shortcode_atts($defaults, $atts);
 
@@ -218,7 +262,8 @@ class Frontend {
             'additionalRequiredFields' => $atts['additional_required_fields'],
             'defaultServiceBodies' => $atts['default_service_bodies'],
             'showFlyer' => $atts['show_flyer'],
-            'showPhone' => $atts['show_phone']
+            'showPhone' => $atts['show_phone'],
+            'timeFormat' => self::resolve_time_format($atts['time_format'])
         ]);
 
         return sprintf(

--- a/readme.txt
+++ b/readme.txt
@@ -189,6 +189,7 @@ This project is licensed under the GPL v2 or later.
 
 = 1.9.2 =
 * Added a JavaScript example (docs/rest-api-javascript-example.md) showing how to pull events from the REST API filtered by service body and tag, resolving the human-readable names to the id/slug the API expects via the facets endpoint. [#302]
+* Fixed the event and announcement submission forms forcing 24-hour ("military") time entry regardless of site settings. Start/End time now follow the WordPress "Time Format" setting (Settings → General), showing 12-hour Hour/Minute/AM-PM selects by default, and can be overridden per form with a new `time_format="12hour|24hour"` shortcode option. [#300]
 * Fixed the calendar view showing an unnecessary scrollbar on every day cell. Day cells now only scroll internally when they actually contain more events than fit. [#298]
 * Added event-type exclusion to the event list: prefix a type with "-" to hide it (e.g. `event_type="-Celebration"` shows Service and Activity events), or list the types to keep (`event_type="Service,Activity"`). Exclusion is future-proof — any event types added later stay visible automatically. [#296]
 * Fixed external feed sources ignoring their configured category filter: a category set on an external source now actually narrows which events are imported, even when the remote site runs an older version, isn't a Mayo site, or uses different category slugs. Previously an unmatched category was silently dropped and the source returned all of its events. Sources with no category configured are unaffected. [#292]

--- a/tests/Unit/FrontendTest.php
+++ b/tests/Unit/FrontendTest.php
@@ -24,6 +24,9 @@ class FrontendTest extends TestCase {
         Functions\when('current_filter')->justReturn('the_content');
         Functions\when('is_active_sidebar')->justReturn(false);
         Functions\when('wp_get_sidebars_widgets')->justReturn([]);
+        // resolve_time_format() reads the WordPress "Time Format" setting when a
+        // form's time_format attribute is left empty.
+        Functions\when('get_option')->justReturn('g:i a');
     }
 
     /**


### PR DESCRIPTION
Closes #300

## Problem

The event and announcement **submission** forms rendered Start/End time with a native `<input type="time">`. The displayed format of that element is dictated by the **browser/OS locale**, not by the plugin or WordPress — so on several sites it forced 24-hour ("military") time entry, which most US civilians find confusing. The value was always stored as canonical 24h `HH:mm`, and the Event Calendar / List / Post Edit already convert it to AM/PM for display — only the input side regressed.

## Fix

- **Shared `TimeField` component** (`assets/js/src/components/public/TimeField.js`) presents:
  - **12-hour:** Hour (1–12) / Minute / AM–PM selects
  - **24-hour:** Hour (0–23) / Minute selects (deterministic — no reliance on browser locale)

  It parses the incoming `HH:mm` value and always emits a canonical 24h `HH:mm` via a synthetic change event, so form storage and all downstream display are unchanged.
- **Server resolves the format** (`includes/Frontend.php`): a new `resolve_time_format()` helper derives `12hour`/`24hour` from the WordPress **Settings → General → Time Format** option by default, and both `render_event_form` and `render_announcement_form` pass it to JS. A new `time_format="12hour|24hour"` shortcode attribute can override per form.
- Applied to **both** `EventForm.js` and `AnnouncementForm.js` (both had the same native-input bug).

## Testing

- `npm run build` compiles cleanly; `php -l` passes on `Frontend.php`.
- Manual: with WP Time Format = 12-hour, the forms show Hour/Minute/AM-PM and 7:30 PM stores as `19:30` and displays as `7:30 PM`. With 24-hour, forms show 0–23 hour + minute and round-trip the same value. `[mayo_event_form time_format="24hour"]` overrides the WP option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGXVGBiyvPyLCesFqS91d1