### PR TITLE
Show richer event detail in the JS example

### DIFF
--- a/docs/rest-api-javascript-example.md
+++ b/docs/rest-api-javascript-example.md
@@ -108,20 +108,37 @@ Other handy params the endpoint accepts: `per_page`, `page`, `order` (`ASC`/`DES
       return;
     }
 
+    // "2026-07-19 11:00 – 16:00" for a same-day event; spans the dates when the
+    // event runs across days ("2026-12-31 12:00 – 2027-01-02 13:00").
+    const formatWhen = (m) => {
+      const start = [m.event_start_date, m.event_start_time].filter(Boolean).join(' ');
+      let end = '';
+      if (m.event_end_date && m.event_end_date !== m.event_start_date) {
+        end = [m.event_end_date, m.event_end_time].filter(Boolean).join(' ');
+      } else if (m.event_end_time) {
+        end = m.event_end_time; // same day — just the closing time
+      }
+      return end ? `${start} – ${end}` : start;
+    };
+
+    // Full location: venue name, street address, then any extra details.
+    const formatWhere = (m) =>
+      [m.location_name, m.location_address, m.location_details]
+        .filter(Boolean)
+        .join(' · ');
+
     container.innerHTML = `
       <h2>${serviceBody.name} — ${tag.name} events (${pagination.total})</h2>
       <ul>
         ${events.map((event) => {
-          const when = [event.meta.event_start_date, event.meta.event_start_time]
-            .filter(Boolean)
-            .join(' ');
-          const where = event.meta.location_name
-            ? ` — ${event.meta.location_name}`
-            : '';
-          // title comes back as { rendered: '...' }; link is the permalink.
+          const m = event.meta;
+          // title comes back as { rendered: '...' }.
           return `<li>
-            <a href="${event.link}">${event.title.rendered}</a>
-            <br><small>${when}${where}</small>
+            <strong>${event.title.rendered}</strong><br>
+            <small>
+              When: ${formatWhen(m)}<br>
+              Where: ${formatWhere(m) || 'Location TBD'}
+            </small>
           </li>`;
         }).join('')}
       </ul>`;


### PR DESCRIPTION
Follow-up to #303 (already merged).

Updates the render block in `docs/rest-api-javascript-example.md` per feedback:
- Show both **start and end times** (and spanning dates when an event runs across days, e.g. `2026-12-31 12:00 – 2027-01-02 13:00`).
- Show the **full address** — venue name, street address, and any location details.
- **Remove the link** to the event; the title now renders as plain text.

Verified the field names against the live nanj.org feed: `event_end_date`, `event_end_time`, `location_address`, and `location_details` are all present and rendered.

Refs #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qhzc67oVYG5NsCp3naTPDu