### PR TITLE
Fix End Date/Time overlapping Start Date/Time on submission forms [#310]

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1005,6 +1005,10 @@
 .mayo-time-inputs select {
     flex: 1;
     min-width: 0;
+    /* Override the global `.mayo-form-field select { width: 100% }` so the
+       AM/PM select (flex: 0 0 auto) doesn't take a 100% flex-basis and
+       overflow the column, overlapping the adjacent Start/End field (#310). */
+    width: auto;
 }
 
 .mayo-time-inputs .mayo-time-ampm,

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.2 =
+* Fixed the event and announcement submission forms overlapping the End Date/Time field on top of the Start Date/Time field, which happened after Start/End time became Hour/Minute/AM-PM dropdowns. [#310]
 * Added date defaults to the event submission form: the Start Date now pre-fills to today's date and the End Date automatically matches the Start Date (until you set a different end date), so single-day events need only one date entry. [#301]
 * Added a JavaScript example (docs/rest-api-javascript-example.md) showing how to pull events from the REST API filtered by service body and tag, resolving the human-readable names to the id/slug the API expects via the facets endpoint. [#302]
 * Fixed the event and announcement submission forms forcing 24-hour ("military") time entry regardless of site settings. Start/End time now follow the WordPress "Time Format" setting (Settings → General), showing 12-hour Hour/Minute/AM-PM selects by default, and can be overridden per form with a new `time_format="12hour|24hour"` shortcode option. [#300]


### PR DESCRIPTION
Closes #310

## Problem

After #300 (PR #305) replaced the native `<input type="time">` on the event and announcement submission forms with Hour/Minute/AM-PM `<select>` dropdowns, the **End Date/Time** field visually overlapped the **Start Date/Time** field (reported on 1.9.2-beta1).

## Root cause

The two date/time fields sit side-by-side in `.mayo-datetime-group`. The shipped global rule `.mayo-form-field select { width: 100% }` applies to the new time `<select>`s:

- **Hour / Minute** survive it — `.mayo-time-inputs select { flex: 1; min-width: 0 }` gives `flex-basis: 0%`, which overrides `width` for flex sizing.
- **AM/PM** does not — `.mayo-time-inputs .mayo-time-ampm { flex: 0 0 auto }` wins on specificity, so `flex-basis: auto` falls back to `width: 100%`. Being non-shrinkable (`flex-shrink: 0`), it becomes rigidly 100% of its container and overflows the column, spilling onto the adjacent field.

## Fix

Add `width: auto` to `.mayo-time-inputs select` so the shipped `width: 100%` no longer forces the AM/PM select to fill/overflow the flex container. CSS-only (`public.css` is enqueued directly — no JS rebuild), and both the event and announcement forms share this structure so both are fixed.

## Testing

- Rendered `[mayo_event_form]` / `[mayo_announcement_form]` at ~615px (matching the report): Start and End columns now sit side-by-side with no overlap; AM/PM sits inline after Minute within its own column.
- 24-hour mode (`time_format="24hour"`, no AM/PM select) and the ≤600px stacked layout both unchanged.
- Values still store as canonical `HH:mm` (layout-only change).