### PR TITLE
Add "relative to a monthly day" recurrence [#312]

### DIFF
--- a/assets/js/src/components/admin/EventBlockEditorSidebar.js
+++ b/assets/js/src/components/admin/EventBlockEditorSidebar.js
@@ -85,7 +85,9 @@ const EventBlockEditorSidebar = () => {
         endDate: '',
         monthlyType: 'date',
         monthlyDate: '',
-        monthlyWeekday: ''
+        monthlyWeekday: '',
+        relativeOffsetWeekday: 1,
+        relativeOffsetDirection: 'before'
     };
 
     const updateRecurringPattern = (updates) => {
@@ -306,12 +308,17 @@ const EventBlockEditorSidebar = () => {
                                 selected={recurringPattern.monthlyType || 'date'}
                                 options={[
                                     { label: __('On a specific date', 'mayo-events-manager'), value: 'date' },
-                                    { label: __('On a specific day', 'mayo-events-manager'), value: 'weekday' }
+                                    { label: __('On a specific day', 'mayo-events-manager'), value: 'weekday' },
+                                    { label: __('Relative to a monthly day', 'mayo-events-manager'), value: 'relative' }
                                 ]}
                                 onChange={value => updateRecurringPattern({
                                     monthlyType: value,
                                     monthlyDate: value === 'date' ? getInitialMonthlyDate() : '',
-                                    monthlyWeekday: value === 'weekday' ? getInitialWeekdayPattern() : ''
+                                    monthlyWeekday: (value === 'weekday' || value === 'relative') ? getInitialWeekdayPattern() : '',
+                                    ...(value === 'relative' ? {
+                                        relativeOffsetDirection: recurringPattern.relativeOffsetDirection || 'before',
+                                        relativeOffsetWeekday: recurringPattern.relativeOffsetWeekday ?? 1
+                                    } : {})
                                 })}
                             />
 
@@ -353,6 +360,64 @@ const EventBlockEditorSidebar = () => {
                                         __nextHasNoMarginBottom={true}
                                         __next40pxDefaultSize={true}
                                     />
+                                </div>
+                            )}
+
+                            {recurringPattern.monthlyType === 'relative' && (
+                                <div className="mayo-monthly-relative">
+                                    <p className="components-base-control__label">
+                                        {__('Anchor day', 'mayo-events-manager')}
+                                    </p>
+                                    <div className="mayo-monthly-weekday">
+                                        <SelectControl
+                                            label={__('Week', 'mayo-events-manager')}
+                                            value={recurringPattern.monthlyWeekday?.split(',')[0] || '1'}
+                                            options={weekNumbers}
+                                            onChange={value => {
+                                                const currentDay = recurringPattern.monthlyWeekday?.split(',')[1] || '0';
+                                                updateRecurringPattern({
+                                                    monthlyWeekday: `${value},${currentDay}`
+                                                });
+                                            }}
+                                            __nextHasNoMarginBottom={true}
+                                            __next40pxDefaultSize={true}
+                                        />
+                                        <SelectControl
+                                            label={__('Day', 'mayo-events-manager')}
+                                            value={recurringPattern.monthlyWeekday?.split(',')[1] || '0'}
+                                            options={weekdays}
+                                            onChange={value => {
+                                                const currentWeek = recurringPattern.monthlyWeekday?.split(',')[0] || '1';
+                                                updateRecurringPattern({
+                                                    monthlyWeekday: `${currentWeek},${value}`
+                                                });
+                                            }}
+                                            __nextHasNoMarginBottom={true}
+                                            __next40pxDefaultSize={true}
+                                        />
+                                    </div>
+                                    <SelectControl
+                                        label={__('Offset', 'mayo-events-manager')}
+                                        value={recurringPattern.relativeOffsetDirection || 'before'}
+                                        options={[
+                                            { label: __('Before', 'mayo-events-manager'), value: 'before' },
+                                            { label: __('After', 'mayo-events-manager'), value: 'after' }
+                                        ]}
+                                        onChange={value => updateRecurringPattern({ relativeOffsetDirection: value })}
+                                        __nextHasNoMarginBottom={true}
+                                        __next40pxDefaultSize={true}
+                                    />
+                                    <SelectControl
+                                        label={__('Target day', 'mayo-events-manager')}
+                                        value={String(recurringPattern.relativeOffsetWeekday ?? 1)}
+                                        options={weekdays.map(day => ({ label: day.label, value: String(day.value) }))}
+                                        onChange={value => updateRecurringPattern({ relativeOffsetWeekday: parseInt(value, 10) })}
+                                        __nextHasNoMarginBottom={true}
+                                        __next40pxDefaultSize={true}
+                                    />
+                                    <p className="components-base-control__help">
+                                        {__('The occurrence lands on the nearest target day strictly before or after the anchor day (e.g. the Monday before the 3rd Tuesday).', 'mayo-events-manager')}
+                                    </p>
                                 </div>
                             )}
                         </div>

--- a/assets/js/src/util.js
+++ b/assets/js/src/util.js
@@ -97,7 +97,7 @@ export const formatDateTimeDisplay = (event, timeFormat) => {
 export const formatRecurringPattern = (pattern) => {
     if (!pattern || pattern.type === 'none') return '';
 
-    const { type, interval, weekdays = [], endDate, monthlyType, monthlyWeekday, monthlyDate } = pattern;
+    const { type, interval, weekdays = [], endDate, monthlyType, monthlyWeekday, monthlyDate, relativeOffsetWeekday, relativeOffsetDirection } = pattern;
     let text = '';
 
     switch (type) {
@@ -154,6 +154,28 @@ export const formatRecurringPattern = (pattern) => {
                 text += ' ' + sprintf(
                     /* translators: 1: ordinal week (e.g. "first"), 2: weekday name */
                     __('on the %1$s %2$s', 'mayo-events-manager'),
+                    weekText,
+                    dayNames[weekday]
+                );
+            } else if (monthlyType === 'relative' && monthlyWeekday) {
+                const [week, weekday] = monthlyWeekday.split(',').map(Number);
+                const weekTexts = [
+                    __('first', 'mayo-events-manager'),
+                    __('second', 'mayo-events-manager'),
+                    __('third', 'mayo-events-manager'),
+                    __('fourth', 'mayo-events-manager'),
+                    __('fifth', 'mayo-events-manager')
+                ];
+                const weekText = week > 0 ? weekTexts[week - 1] : __('last', 'mayo-events-manager');
+                const targetDay = dayNames[parseInt(relativeOffsetWeekday ?? 1)];
+                const direction = relativeOffsetDirection === 'after'
+                    ? __('after', 'mayo-events-manager')
+                    : __('before', 'mayo-events-manager');
+                text += ' ' + sprintf(
+                    /* translators: 1: target weekday (e.g. "Monday"), 2: "before"/"after", 3: ordinal week (e.g. "third"), 4: anchor weekday (e.g. "Tuesday") */
+                    __('on the %1$s %2$s the %3$s %4$s', 'mayo-events-manager'),
+                    targetDay,
+                    direction,
                     weekText,
                     dayNames[weekday]
                 );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -515,6 +515,8 @@ class Admin {
                         'monthlyType'  => ['type' => 'string'],
                         'monthlyDate'  => ['type' => 'string'],
                         'monthlyWeekday' => ['type' => 'string'],
+                        'relativeOffsetWeekday' => ['type' => 'integer'],
+                        'relativeOffsetDirection' => ['type' => 'string'],
                         'endDate'      => ['type' => 'string']
                     ]
                 ]
@@ -528,6 +530,8 @@ class Admin {
                 'monthlyType' => 'date',
                 'monthlyDate' => '',
                 'monthlyWeekday' => '',
+                'relativeOffsetWeekday' => 1,
+                'relativeOffsetDirection' => 'before',
                 'endDate' => ''
             ],
             'auth_callback' => function() { 

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -139,8 +139,20 @@ class EventsController {
                 $sanitized_pattern['weekdays'] = array_map('intval', $recurring_pattern['weekdays']);
             } elseif (isset($recurring_pattern['type']) && $recurring_pattern['type'] === 'monthly') {
                 $sanitized_pattern['monthlyType'] = isset($recurring_pattern['monthlyType']) ? sanitize_text_field($recurring_pattern['monthlyType']) : 'date';
-                if (isset($recurring_pattern['monthlyType']) && $recurring_pattern['monthlyType'] === 'date' && isset($recurring_pattern['monthlyDate'])) {
+                if ($sanitized_pattern['monthlyType'] === 'date' && isset($recurring_pattern['monthlyDate'])) {
                     $sanitized_pattern['monthlyDate'] = intval($recurring_pattern['monthlyDate']);
+                } elseif ($sanitized_pattern['monthlyType'] === 'relative') {
+                    // Anchor (e.g. "3,2" = 3rd Tuesday) kept as text; offset lands on a target weekday.
+                    if (isset($recurring_pattern['monthlyWeekday'])) {
+                        $sanitized_pattern['monthlyWeekday'] = sanitize_text_field($recurring_pattern['monthlyWeekday']);
+                    }
+                    $sanitized_pattern['relativeOffsetWeekday'] = isset($recurring_pattern['relativeOffsetWeekday'])
+                        ? max(0, min(6, intval($recurring_pattern['relativeOffsetWeekday'])))
+                        : 1;
+                    $direction = isset($recurring_pattern['relativeOffsetDirection'])
+                        ? sanitize_text_field($recurring_pattern['relativeOffsetDirection'])
+                        : 'before';
+                    $sanitized_pattern['relativeOffsetDirection'] = in_array($direction, ['before', 'after'], true) ? $direction : 'before';
                 } elseif (isset($recurring_pattern['monthlyWeekday'])) {
                     $sanitized_pattern['monthlyWeekday'] = sanitize_text_field($recurring_pattern['monthlyWeekday']);
                 }
@@ -906,6 +918,34 @@ class EventsController {
                         if (isset($recurring_pattern['monthlyType']) && $recurring_pattern['monthlyType'] === 'date' && isset($recurring_pattern['monthlyDate'])) {
                             /* translators: %s: day of the month */
                             $recurring_info .= ' ' . sprintf(__('on day %s', 'mayo-events-manager'), $recurring_pattern['monthlyDate']);
+                        } elseif (isset($recurring_pattern['monthlyType']) && $recurring_pattern['monthlyType'] === 'relative' && isset($recurring_pattern['monthlyWeekday'])) {
+                            $day_names = [
+                                __('Sunday', 'mayo-events-manager'),
+                                __('Monday', 'mayo-events-manager'),
+                                __('Tuesday', 'mayo-events-manager'),
+                                __('Wednesday', 'mayo-events-manager'),
+                                __('Thursday', 'mayo-events-manager'),
+                                __('Friday', 'mayo-events-manager'),
+                                __('Saturday', 'mayo-events-manager'),
+                            ];
+                            $week_ordinals = [
+                                1 => __('first', 'mayo-events-manager'),
+                                2 => __('second', 'mayo-events-manager'),
+                                3 => __('third', 'mayo-events-manager'),
+                                4 => __('fourth', 'mayo-events-manager'),
+                                5 => __('fifth', 'mayo-events-manager'),
+                            ];
+                            list($anchor_week, $anchor_weekday) = array_map('intval', explode(',', $recurring_pattern['monthlyWeekday']));
+                            $week_text = $anchor_week > 0
+                                ? ($week_ordinals[$anchor_week] ?? $anchor_week)
+                                : __('last', 'mayo-events-manager');
+                            $anchor_day_name = $day_names[$anchor_weekday] ?? '';
+                            $target_day_name = $day_names[max(0, min(6, (int)($recurring_pattern['relativeOffsetWeekday'] ?? 1)))] ?? '';
+                            $direction = (isset($recurring_pattern['relativeOffsetDirection']) && $recurring_pattern['relativeOffsetDirection'] === 'after')
+                                ? __('after', 'mayo-events-manager')
+                                : __('before', 'mayo-events-manager');
+                            /* translators: 1: target weekday (e.g. "Monday"), 2: "before"/"after", 3: ordinal week (e.g. "third"), 4: anchor weekday (e.g. "Tuesday") */
+                            $recurring_info .= ' ' . sprintf(__('on the %1$s %2$s the %3$s %4$s', 'mayo-events-manager'), $target_day_name, $direction, $week_text, $anchor_day_name);
                         } elseif (isset($recurring_pattern['monthlyWeekday'])) {
                             /* translators: %s: ordinal weekday description, e.g. "first Monday" */
                             $recurring_info .= ' ' . sprintf(__('on %s', 'mayo-events-manager'), $recurring_pattern['monthlyWeekday']);
@@ -1856,10 +1896,36 @@ class EventsController {
                     }
                 }
 
-                if ($current <= $end || $end === null) {
-                    $current_date = $current->format('Y-m-d');
-                    if (!in_array($current_date, $skipped_occurrences)) {
-                        $events[] = self::format_recurring_event($post, clone $current);
+                // For the "relative to a monthly day" pattern, $current now holds the
+                // anchor date (e.g. the 3rd Tuesday). Step to the nearest target weekday
+                // strictly before/after it. The offset date is what we emit and test.
+                $occurrence = clone $current;
+                if (isset($pattern['monthlyType']) && $pattern['monthlyType'] === 'relative') {
+                    $anchor_dow = (int)$current->format('w');
+                    $target_dow = max(0, min(6, (int)($pattern['relativeOffsetWeekday'] ?? 1)));
+                    $direction = (isset($pattern['relativeOffsetDirection']) && $pattern['relativeOffsetDirection'] === 'after')
+                        ? 'after'
+                        : 'before';
+
+                    if ($direction === 'before') {
+                        $days = ($anchor_dow - $target_dow + 7) % 7;
+                        if ($days === 0) {
+                            $days = 7;
+                        }
+                        $occurrence->modify('-' . $days . ' day');
+                    } else {
+                        $days = ($target_dow - $anchor_dow + 7) % 7;
+                        if ($days === 0) {
+                            $days = 7;
+                        }
+                        $occurrence->modify('+' . $days . ' day');
+                    }
+                }
+
+                if ($occurrence <= $end || $end === null) {
+                    $occurrence_date = $occurrence->format('Y-m-d');
+                    if (!in_array($occurrence_date, $skipped_occurrences)) {
+                        $events[] = self::format_recurring_event($post, clone $occurrence);
                     }
                 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,9 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.9.3 =
+* Added a "Relative to a monthly day" monthly recurrence option so committee meetings can be scheduled relative to a monthly anchor (e.g. the Monday before the 3rd Tuesday, or the Thursday after it). Available in the block-editor Event sidebar. [#312]
+
 = 1.9.2 =
 * Fixed the event and announcement submission forms overlapping the End Date/Time field on top of the Start Date/Time field, which happened after Start/End time became Hour/Minute/AM-PM dropdowns. [#310]
 * Added date defaults to the event submission form: the Start Date now pre-fills to today's date and the End Date automatically matches the Start Date (until you set a different end date), so single-day events need only one date entry. [#301]

--- a/tests/Unit/Rest/EventsControllerTest.php
+++ b/tests/Unit/Rest/EventsControllerTest.php
@@ -1735,6 +1735,178 @@ class EventsControllerTest extends TestCase {
     }
 
     /**
+     * Invoke the private static generate_recurring_events and return the
+     * generated occurrence start dates (Y-m-d) in order.
+     *
+     * @return string[]
+     */
+    private function generatedRecurringDates(\WP_Post $post, array $pattern): array {
+        $method = new \ReflectionMethod(EventsController::class, 'generate_recurring_events');
+        $method->setAccessible(true);
+        $events = $method->invoke(null, $post, $pattern);
+
+        return array_map(function ($event) {
+            return $event['meta']['event_start_date'];
+        }, $events);
+    }
+
+    /**
+     * Set up the common WP function stubs needed to format a recurring event.
+     */
+    private function stubRecurringFormatters(string $title): void {
+        $this->mockGetTheTitle($title);
+        $this->mockHasPostThumbnail(false);
+        Functions\when('wp_get_post_terms')->justReturn([]);
+        Functions\when('get_term_link')->justReturn('https://example.com/category/test');
+    }
+
+    /**
+     * "Monday before the 3rd Tuesday" (anchor "3,2", before, target Monday)
+     * must land on the Monday immediately preceding the 3rd Tuesday each month.
+     */
+    public function testRelativeMonthlyMondayBeforeThirdTuesday(): void {
+        $post = $this->createMockPost([
+            'ID' => 620,
+            'post_title' => 'Fellowship Development',
+            'post_type' => 'mayo_event',
+            'post_status' => 'publish'
+        ]);
+        $this->mockGetPost($post);
+        $this->stubRecurringFormatters('Fellowship Development');
+
+        $this->setPostMeta(620, [
+            'event_start_date' => '2025-01-01',
+            'event_end_date' => '2025-01-01',
+            'skipped_occurrences' => []
+        ]);
+
+        $dates = $this->generatedRecurringDates($post, [
+            'type' => 'monthly',
+            'interval' => 1,
+            'monthlyType' => 'relative',
+            'monthlyWeekday' => '3,2',
+            'relativeOffsetWeekday' => 1,
+            'relativeOffsetDirection' => 'before',
+            'endDate' => '2025-06-30'
+        ]);
+
+        $this->assertSame(
+            ['2025-02-17', '2025-03-17', '2025-04-14', '2025-05-19', '2025-06-16'],
+            $dates
+        );
+    }
+
+    /**
+     * "Thursday after the 3rd Tuesday" (anchor "3,2", after, target Thursday)
+     * must land on the Thursday immediately following the 3rd Tuesday.
+     */
+    public function testRelativeMonthlyThursdayAfterThirdTuesday(): void {
+        $post = $this->createMockPost([
+            'ID' => 621,
+            'post_title' => 'Public Relations',
+            'post_type' => 'mayo_event',
+            'post_status' => 'publish'
+        ]);
+        $this->mockGetPost($post);
+        $this->stubRecurringFormatters('Public Relations');
+
+        $this->setPostMeta(621, [
+            'event_start_date' => '2025-01-01',
+            'event_end_date' => '2025-01-01',
+            'skipped_occurrences' => []
+        ]);
+
+        $dates = $this->generatedRecurringDates($post, [
+            'type' => 'monthly',
+            'interval' => 1,
+            'monthlyType' => 'relative',
+            'monthlyWeekday' => '3,2',
+            'relativeOffsetWeekday' => 4,
+            'relativeOffsetDirection' => 'after',
+            'endDate' => '2025-06-30'
+        ]);
+
+        $this->assertSame(
+            ['2025-02-20', '2025-03-20', '2025-04-17', '2025-05-22', '2025-06-19'],
+            $dates
+        );
+    }
+
+    /**
+     * The offset date may legitimately fall in the adjacent month. With anchor
+     * "1,2" (1st Tuesday) and Monday-before, April 2025's 1st Tuesday is Apr 1,
+     * so the occurrence lands on Mar 31 — the prior month. This is expected.
+     */
+    public function testRelativeMonthlyOffsetCrossesMonthBoundary(): void {
+        $post = $this->createMockPost([
+            'ID' => 622,
+            'post_title' => 'Boundary Crosser',
+            'post_type' => 'mayo_event',
+            'post_status' => 'publish'
+        ]);
+        $this->mockGetPost($post);
+        $this->stubRecurringFormatters('Boundary Crosser');
+
+        $this->setPostMeta(622, [
+            'event_start_date' => '2025-01-01',
+            'event_end_date' => '2025-01-01',
+            'skipped_occurrences' => []
+        ]);
+
+        $dates = $this->generatedRecurringDates($post, [
+            'type' => 'monthly',
+            'interval' => 1,
+            'monthlyType' => 'relative',
+            'monthlyWeekday' => '1,2',
+            'relativeOffsetWeekday' => 1,
+            'relativeOffsetDirection' => 'before',
+            'endDate' => '2025-05-31'
+        ]);
+
+        // Feb 3, Mar 3, Mar 31 (April's 1st Tue is Apr 1 → Monday before is Mar 31), May 5.
+        $this->assertSame(
+            ['2025-02-03', '2025-03-03', '2025-03-31', '2025-05-05'],
+            $dates
+        );
+    }
+
+    /**
+     * skipped_occurrences must be honored against the offset date, not the anchor.
+     */
+    public function testRelativeMonthlySkipsOffsetDate(): void {
+        $post = $this->createMockPost([
+            'ID' => 623,
+            'post_title' => 'Skips Offset',
+            'post_type' => 'mayo_event',
+            'post_status' => 'publish'
+        ]);
+        $this->mockGetPost($post);
+        $this->stubRecurringFormatters('Skips Offset');
+
+        $this->setPostMeta(623, [
+            'event_start_date' => '2025-01-01',
+            'event_end_date' => '2025-01-01',
+            'skipped_occurrences' => ['2025-03-17']
+        ]);
+
+        $dates = $this->generatedRecurringDates($post, [
+            'type' => 'monthly',
+            'interval' => 1,
+            'monthlyType' => 'relative',
+            'monthlyWeekday' => '3,2',
+            'relativeOffsetWeekday' => 1,
+            'relativeOffsetDirection' => 'before',
+            'endDate' => '2025-06-30'
+        ]);
+
+        $this->assertNotContains('2025-03-17', $dates);
+        $this->assertSame(
+            ['2025-02-17', '2025-04-14', '2025-05-19', '2025-06-16'],
+            $dates
+        );
+    }
+
+    /**
      * Test get_events hides events after their end time passes
      *
      * This test verifies the fix for issue #237 where events remained visible


### PR DESCRIPTION
Closes #312

## What
Adds a third monthly recurrence mode — **Relative to a monthly day** — so service bodies can schedule committee meetings relative to a monthly anchor meeting. Real examples now expressible:

- **Bergen Area Service** = 3rd Tuesday (existing `weekday` mode).
- **Fellowship Development** = the **Monday before** the 3rd Tuesday.
- **Public Relations** = the **Thursday after** the 3rd Tuesday.

## How
The pattern is **self-contained** — no cross-event references. It extends `recurring_pattern` with `monthlyType: 'relative'`, reusing the existing `monthlyWeekday` (`"week,weekday"`) field to store the anchor (e.g. `"3,2"` = 3rd Tuesday), plus two new fields:

- `relativeOffsetWeekday` (int 0–6, Sun=0) — the target weekday to land on.
- `relativeOffsetDirection` (`before` | `after`).

**Offset semantics (strict / nearest):**
- `before`: `daysBack = ((anchorDow - targetDow + 7) % 7)`; `0 → 7`; `date = anchor − daysBack`.
- `after`: `daysFwd = ((targetDow - anchorDow + 7) % 7)`; `0 → 7`; `date = anchor + daysFwd`.

The occurrence (offset) date is what gets emitted, compared against the end date, and matched against `skipped_occurrences`. Offset dates may legitimately fall in the adjacent month — expected. `interval` (every N months) still applies to the anchor.

## Changes
- **includes/Admin.php** — `relativeOffsetWeekday` / `relativeOffsetDirection` added to the `recurring_pattern` schema + defaults.
- **includes/Rest/EventsController.php** — sanitize the new fields on submit (clamp 0–6, whitelist before/after); compute + emit the offset date in `generate_recurring_events`; human-readable REST/email text summary (e.g. "Monthly on the Monday before the third Tuesday").
- **assets/js/src/util.js** — `formatRecurringPattern` renders the relative description.
- **assets/js/src/components/admin/EventBlockEditorSidebar.js** — new "Relative to a monthly day" radio option with anchor (week + day), offset direction, and target-weekday controls. **Admin block editor only** — the public submission form is unchanged.
- **tests/Unit/Rest/EventsControllerTest.php** — Monday-before, Thursday-after, a month-boundary crossing, and offset-date skipping.
- **readme.txt** — changelog entry under a new `1.9.3` section.

## Verification
- `composer test` → **OK (544 tests, 1222 assertions)** including 4 new relative-recurrence tests verifying the three real examples across ≥3 consecutive months plus a month-boundary crossing (April's 1st Tuesday → Monday-before lands on Mar 31).
- `npm run build` succeeds.
- Public submission form untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01679ChUcsgefpYoPP6cuaGM