### PR TITLE
Bump version to 1.9.3

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.9.2
+ * Version: 1.9.3
  * Requires at least: 6.7
  * Tested up to: 7.0
  * Author: bmlt-enabled
@@ -24,7 +24,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.9.2');
+define('MAYO_VERSION', '1.9.3');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mayo",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mayo",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-react": "^7.26.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Closes #314

Bumps every version string from `1.9.2` → `1.9.3` so the `1.9.3` release tag ships a build that self-reports the correct version. Without this, the WordPress `Stable tag` would stay `1.9.2` and the plugin's `version_compare($current, MAYO_VERSION, '<')` upgrade routine would never fire for 1.9.3.

## Changes
- `mayo-events-manager.php` — plugin header `Version` and `MAYO_VERSION` constant → `1.9.3`
- `package.json` / `package-lock.json` — root `version` → `1.9.3`
- `readme.txt` — `Stable tag` → `1.9.3`

The `= 1.9.3 =` changelog section already exists from #313 and is left untouched. No functional changes.

## Verification
- `grep -rn "1\.9\.2"` on the four files returns only the historical `= 1.9.2 =` changelog header
- `make lint` — clean
- `make test` — OK (544 tests)
- `npm run build` — webpack compiled successfully

Once merged, the `1.9.3` release tag can be cut at the resulting `main` commit.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow