### PR TITLE
Fix filter-bar regressions in calendar view and external feeds [#251]

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1981,7 +1981,7 @@
     z-index: 50;
     min-width: 200px;
     max-width: 280px;
-    max-height: 320px;
+    max-height: 260px;
     overflow-y: auto;
     background: #fff;
     border: 1px solid #c3c4c7;

--- a/assets/js/src/components/public/CalendarView.js
+++ b/assets/js/src/components/public/CalendarView.js
@@ -4,8 +4,12 @@ import EventModal from './EventModal';
 import { useEventProvider } from '../providers/EventProvider';
 import { convertToUnicode } from '../../util';
 
-const CalendarView = ({ events, timeFormat, onMonthChange, loading }) => {
-    const [currentDate, setCurrentDate] = useState(new Date());
+const CalendarView = ({ events, timeFormat, currentDate: currentDateProp, onMonthChange, loading }) => {
+    // The displayed month is controlled by the parent (EventList) so that it
+    // survives re-renders and remounts triggered by filter changes. Fall back
+    // to internal state only when no controlled value is supplied.
+    const [internalDate, setInternalDate] = useState(new Date());
+    const currentDate = currentDateProp instanceof Date ? currentDateProp : internalDate;
     const [selectedEvent, setSelectedEvent] = useState(null);
     const [hoveredEvent, setHoveredEvent] = useState(null);
     const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
@@ -208,7 +212,7 @@ const CalendarView = ({ events, timeFormat, onMonthChange, loading }) => {
 
     const goToPreviousMonth = () => {
         const newDate = new Date(year, month - 1, 1);
-        setCurrentDate(newDate);
+        setInternalDate(newDate);
         if (onMonthChange) {
             onMonthChange(newDate);
         }
@@ -216,7 +220,7 @@ const CalendarView = ({ events, timeFormat, onMonthChange, loading }) => {
 
     const goToNextMonth = () => {
         const newDate = new Date(year, month + 1, 1);
-        setCurrentDate(newDate);
+        setInternalDate(newDate);
         if (onMonthChange) {
             onMonthChange(newDate);
         }
@@ -224,7 +228,7 @@ const CalendarView = ({ events, timeFormat, onMonthChange, loading }) => {
 
     const goToToday = () => {
         const newDate = new Date();
-        setCurrentDate(newDate);
+        setInternalDate(newDate);
         if (onMonthChange) {
             onMonthChange(newDate);
         }

--- a/assets/js/src/components/public/EventFilters.js
+++ b/assets/js/src/components/public/EventFilters.js
@@ -164,6 +164,10 @@ const EventFilters = ({ facets, selected, onToggle, onClear, lockedFilters, disa
                                                     onClick={() => {
                                                         if (!disabled) {
                                                             onToggle(def.key, option.value);
+                                                            // Close the panel after a selection so it
+                                                            // stops covering the content below (e.g. the
+                                                            // first days of the calendar).
+                                                            setOpenFacet(null);
                                                         }
                                                     }}
                                                 >

--- a/assets/js/src/components/public/EventList.js
+++ b/assets/js/src/components/public/EventList.js
@@ -637,6 +637,13 @@ const EventList = ({ widget = false, settings = {} }) => {
 
     const hasActiveFilters = Object.values(activeFilters).some(arr => Array.isArray(arr) && arr.length > 0);
 
+    // In calendar view the calendar renders from its own calendarEvents /
+    // calendarLoading state, so the list-level loading/error/empty early
+    // returns below must not fire — otherwise a filter change (which clears
+    // `events` and flips `loading`) would unmount the calendar and reset the
+    // navigated month back to today.
+    const isCalendarView = viewMode === 'calendar' && !isWidget;
+
     const renderFilters = () => (!isWidget ? (
         <EventFilters
             facets={facets}
@@ -648,7 +655,7 @@ const EventList = ({ widget = false, settings = {} }) => {
         />
     ) : null);
 
-    if (loading && events.length === 0) {
+    if (loading && events.length === 0 && !isCalendarView) {
         return (
             <div className="mayo-event-list" ref={containerRef}>
                 {renderFilters()}
@@ -656,7 +663,7 @@ const EventList = ({ widget = false, settings = {} }) => {
             </div>
         );
     }
-    if (error && events.length === 0) {
+    if (error && events.length === 0 && !isCalendarView) {
         return (
             <div className="mayo-event-list" ref={containerRef}>
                 {renderFilters()}
@@ -664,7 +671,7 @@ const EventList = ({ widget = false, settings = {} }) => {
             </div>
         );
     }
-    if (!events.length) {
+    if (!events.length && !isCalendarView) {
         const emptyMessage = hasActiveFilters
             ? <div className="mayo-no-events">{__('No events match the selected filters.', 'mayo-events-manager')}</div>
             : (settings?.showArchived
@@ -824,6 +831,7 @@ const EventList = ({ widget = false, settings = {} }) => {
                         <CalendarView
                             events={calendarEvents}
                             timeFormat={timeFormat}
+                            currentDate={calendarDate}
                             onMonthChange={handleCalendarMonthChange}
                             loading={calendarLoading}
                         />

--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1304,6 +1304,51 @@ class EventsController {
     }
 
     /**
+     * Test whether a single event's type satisfies an event_type filter string.
+     *
+     * Uses the same token grammar as build_event_type_meta_query (comma-separated
+     * includes, "-" prefixed excludes), but evaluates it in PHP against an
+     * already-fetched event rather than building a WP meta_query. Used to
+     * re-enforce the filter on external-feed events, whose remote may not honor
+     * the forwarded param.
+     *
+     * @param string $eventType The event's own type (e.g. 'Service').
+     * @param string $filter     Raw event_type filter value (e.g. 'Service,-Celebration').
+     * @return bool True when the event should be kept.
+     */
+    private static function event_matches_event_type_filter($eventType, $filter) {
+        $filter = trim((string) $filter);
+        if ($filter === '') {
+            return true;
+        }
+
+        $includes = [];
+        $excludes = [];
+        foreach (array_map('trim', explode(',', $filter)) as $token) {
+            if ($token === '') {
+                continue;
+            }
+            if (str_starts_with($token, '-')) {
+                $name = trim(substr($token, 1));
+                if ($name !== '') {
+                    $excludes[] = $name;
+                }
+            } else {
+                $includes[] = $token;
+            }
+        }
+
+        $type = trim((string) $eventType);
+        if (!empty($excludes) && in_array($type, $excludes, true)) {
+            return false;
+        }
+        if (!empty($includes) && !in_array($type, $includes, true)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Query events with given parameters
      *
      * @param string $status Post status
@@ -1575,6 +1620,20 @@ class EventsController {
                 }));
             }
 
+            // Enforce the event_type filter locally for the same reason as the
+            // category filter above: the param is forwarded to the remote, but a
+            // remote on an older Mayo (before event_type filtering existed) or a
+            // non-Mayo feed may ignore it and return every type. Re-applying it
+            // here makes the visitor's Service/Activity selection authoritative.
+            // Empty filter = no constraint.
+            $effective_event_type = self::effective_source_filter($source, 'event_type');
+            if ($effective_event_type !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_event_type) {
+                    $type = isset($event['meta']['event_type']) ? $event['meta']['event_type'] : '';
+                    return self::event_matches_event_type_filter($type, $effective_event_type);
+                }));
+            }
+
             // Tag events with source info
             foreach ($events as &$event) {
                 $event['source_id'] = $sid;
@@ -1730,6 +1789,20 @@ class EventsController {
                         $effective_categories,
                         $cat_relation
                     );
+                }));
+            }
+
+            // Enforce the event_type filter locally for the same reason as the
+            // category filter above: the param is forwarded to the remote, but a
+            // remote on an older Mayo (before event_type filtering existed) or a
+            // non-Mayo feed may ignore it and return every type. Re-applying it
+            // here makes the visitor's Service/Activity selection authoritative.
+            // Empty filter = no constraint.
+            $effective_event_type = self::effective_source_filter($source, 'event_type');
+            if ($effective_event_type !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_event_type) {
+                    $type = isset($event['meta']['event_type']) ? $event['meta']['event_type'] : '';
+                    return self::event_matches_event_type_filter($type, $effective_event_type);
                 }));
             }
 

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,11 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.9.4 =
+* Fixed the event filters resetting the calendar back to the current month: selecting a Service Body, Category, Tag, or Event Type filter now keeps the month you had navigated to instead of jumping back to today. [#251]
+* Fixed the filter dropdown staying open after you pick a value; it now closes automatically so it no longer covers the first days of the calendar. [#251]
+* Fixed external feed sources ignoring the Event Type filter: filtering on Service (or Activity) now actually hides the other types coming from external feeds, even when the remote runs an older version or isn't a Mayo site. [#251]
+
 = 1.9.3 =
 * Added a "Relative to a monthly day" monthly recurrence option so committee meetings can be scheduled relative to a monthly anchor (e.g. the Monday before the 3rd Tuesday, or the Thursday after it). Available in the block-editor Event sidebar. [#312]
 

--- a/tests/Unit/Rest/EventsControllerTest.php
+++ b/tests/Unit/Rest/EventsControllerTest.php
@@ -2210,4 +2210,61 @@ class EventsControllerTest extends TestCase {
 
         $this->assertSame('', $this->effectiveSourceFilter([], 'categories'));
     }
+
+    /**
+     * Invoke the private static event_matches_event_type_filter for testing.
+     */
+    private function eventMatchesEventType(string $eventType, string $filter): bool {
+        $method = new \ReflectionMethod(EventsController::class, 'event_matches_event_type_filter');
+        $method->setAccessible(true);
+        return $method->invoke(null, $eventType, $filter);
+    }
+
+    /**
+     * An empty filter constrains nothing — every event type passes. This keeps
+     * external feeds with no event_type selection unaffected.
+     */
+    public function testEventTypeFilterEmptyKeepsEverything(): void {
+        $this->assertTrue($this->eventMatchesEventType('Service', ''));
+        $this->assertTrue($this->eventMatchesEventType('Activity', ''));
+        $this->assertTrue($this->eventMatchesEventType('', ''));
+    }
+
+    /**
+     * The reported bug (#251): filtering on Service must hide Activity events
+     * coming from an external feed. An include filter keeps only its own types.
+     */
+    public function testEventTypeFilterIncludeHidesOtherTypes(): void {
+        $this->assertTrue($this->eventMatchesEventType('Service', 'Service'));
+        $this->assertFalse($this->eventMatchesEventType('Activity', 'Service'));
+        $this->assertFalse($this->eventMatchesEventType('', 'Service'));
+    }
+
+    /**
+     * Multiple include tokens keep any listed type.
+     */
+    public function testEventTypeFilterMultipleIncludes(): void {
+        $this->assertTrue($this->eventMatchesEventType('Service', 'Service,Activity'));
+        $this->assertTrue($this->eventMatchesEventType('Activity', 'Service,Activity'));
+        $this->assertFalse($this->eventMatchesEventType('Celebration', 'Service,Activity'));
+    }
+
+    /**
+     * A "-" prefixed token excludes that type; everything else passes.
+     */
+    public function testEventTypeFilterExcludeHidesOnlyExcluded(): void {
+        $this->assertFalse($this->eventMatchesEventType('Celebration', '-Celebration'));
+        $this->assertTrue($this->eventMatchesEventType('Service', '-Celebration'));
+        $this->assertTrue($this->eventMatchesEventType('Activity', '-Celebration'));
+    }
+
+    /**
+     * Include and exclude tokens can be mixed; exclude wins over an implied
+     * include for the same type.
+     */
+    public function testEventTypeFilterMixedIncludeAndExclude(): void {
+        $this->assertTrue($this->eventMatchesEventType('Service', 'Service,-Celebration'));
+        $this->assertFalse($this->eventMatchesEventType('Activity', 'Service,-Celebration'));
+        $this->assertFalse($this->eventMatchesEventType('Celebration', 'Service,-Celebration'));
+    }
 }


### PR DESCRIPTION
Closes #251

Follow-up bug-fix pass on the display filters reported after the 1.9.0 feature shipped.

## Fixes

**1. Selecting a filter reset the calendar to the current month.**
The `activeFilters` effect clears `events` and flips `loading`, which tripped the list-level `loading && !events.length` early return and unmounted `CalendarView` — remounting reset its internal month state back to today. Now:
- `CalendarView`'s displayed month is controlled by `EventList`'s `calendarDate` (which is preserved across filter changes), so even a remount shows the navigated month.
- The list-level loading/error/empty early returns no longer fire in calendar view (the calendar renders from its own `calendarEvents` / `calendarLoading`), so the calendar stays mounted and just shows its loading overlay while events refetch.

**2. Filter dropdown didn't auto-close on selection.**
Toggling a value now closes the panel, so it stops covering the calendar. Combined with a slightly reduced panel `max-height`, this addresses long Service Body / Category lists covering the first days of the calendar.

**3. External feeds ignored the Event Type filter.**
Only `categories` was re-applied locally on external events; `event_type` was forwarded but a remote on an older Mayo (before event_type filtering existed) or a non-Mayo feed ignores it and returns every type. Added local re-enforcement of `event_type` (mirroring the existing `categories` block, `#292`), so filtering on Service actually hides Activity events from external feeds. Empty filter = no constraint.

## Testing
- `composer test` — 550 tests pass (added 6 unit tests for the `event_type` matcher: include/exclude/mixed/empty).
- `npm run build` — bundles compile.
- Root-file PHPCS errors are pre-existing (unchanged with these changes stashed).