### PR TITLE
Document dash substitution for category slugs in shortcodes

### DIFF
--- a/assets/js/src/components/admin/ShortcodesDocs.js
+++ b/assets/js/src/components/admin/ShortcodesDocs.js
@@ -14,6 +14,13 @@ const ShortcodesDocs = () => {
                     <li><a href="#announcement-form">[mayo_announcement_form] - Announcement Submission Form Shortcode</a></li>
                     <li><a href="#subscribe">[mayo_subscribe] - Email Subscription Form Shortcode</a></li>
                 </ul>
+
+                <h3>Category and Tag Slugs</h3>
+                <p>
+                    Shortcode parameters for <code>categories</code> and <code>tags</code> use WordPress slugs, not display names.
+                    When a category or tag name contains spaces, substitute a dash for each space in the shortcode.
+                    Slugs are case-insensitive. For example, a category named &quot;Cell Awareness&quot; is specified as <code>cell-awareness</code>.
+                </p>
             </div>
 
             <div className="card" id="event-list">
@@ -500,13 +507,13 @@ const ShortcodesDocs = () => {
                         </tr>
                         <tr>
                             <td>categories</td>
-                            <td>Comma-separated list of category slugs that should be available in the form. Prefix a category with a minus sign (-) to exclude it.</td>
+                            <td>Comma-separated list of category slugs that should be available in the form. Prefix a category with a minus sign (-) to exclude it. For names with spaces, substitute a dash for each space (e.g., &quot;Cell Awareness&quot; → <code>cell-awareness</code>).</td>
                             <td>empty (uses subscription settings)</td>
-                            <td>e.g., <pre>announcements,alerts</pre> or <pre>-internal</pre></td>
+                            <td>e.g., <pre>announcements,alerts</pre>, <pre>cell-awareness</pre>, or <pre>-internal</pre></td>
                         </tr>
                         <tr>
                             <td>tags</td>
-                            <td>Comma-separated list of tag slugs that should be available in the form. Prefix a tag with a minus sign (-) to exclude it.</td>
+                            <td>Comma-separated list of tag slugs that should be available in the form. Prefix a tag with a minus sign (-) to exclude it. For names with spaces, substitute a dash for each space.</td>
                             <td>empty (uses subscription settings)</td>
                             <td>e.g., <pre>urgent,featured</pre> or <pre>-archived</pre></td>
                         </tr>
@@ -551,6 +558,10 @@ const ShortcodesDocs = () => {
 
                 <h4>Filter Categories and Tags</h4>
                 <pre><code>[mayo_announcement_form categories="announcements,alerts" tags="urgent,featured"]</code></pre>
+
+                <h4>Category with Spaces in Name</h4>
+                <pre><code>[mayo_announcement_form categories="cell-awareness"]</code></pre>
+                <p><em>For a category named &quot;Cell Awareness&quot;, substitute a dash for each space in the slug.</em></p>
 
                 <h4>Full Configuration</h4>
                 <pre><code>[mayo_announcement_form show_flyer="true" additional_required_fields="start_date,end_date,flyer" default_service_bodies="1,2" categories="announcements"]</code></pre>

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ This project is licensed under the GPL v2 or later.
 == Changelog ==
 
 = 1.9.4 =
+* Documented that category and tag names with spaces should use dashes in shortcode parameters (e.g., a category named "Cell Awareness" is specified as `cell-awareness` in `[mayo_announcement_form]`). [#321]
 * Fixed required start/end date and time fields on the announcement submission form not showing an asterisk (*) on their labels when marked required via `additional_required_fields`. The optional "Leave empty to…" hints are now hidden when those fields are required. [#319]
 * Fixed the event filters resetting the calendar back to the current month: selecting a Service Body, Category, Tag, or Event Type filter now keeps the month you had navigated to instead of jumping back to today. [#251]
 * Fixed the filter dropdown staying open after you pick a value; it now closes automatically so it no longer covers the first days of the calendar. [#251]


### PR DESCRIPTION
## Summary
- Documents that category and tag names with spaces should use dashes in shortcode parameters (e.g., "Cell Awareness" → `cell-awareness`)
- Adds a general "Category and Tag Slugs" section to the admin shortcode docs table of contents
- Adds a `[mayo_announcement_form]` example for categories with spaces in their names

Closes #321

## Test plan
- [ ] Open **Mayo → Shortcodes** in WordPress admin
- [ ] Confirm the "Category and Tag Slugs" note appears in the table of contents card
- [ ] Scroll to the `[mayo_announcement_form]` section and confirm the updated parameter descriptions and "Category with Spaces in Name" example

Made with [Cursor](https://cursor.com)