### PR TITLE
Fix AND filter semantics across local and external event feeds

### DIFF
--- a/includes/Rest/EventsController.php
+++ b/includes/Rest/EventsController.php
@@ -1349,6 +1349,35 @@ class EventsController {
     }
 
     /**
+     * Test whether a single event's service body satisfies a service_body filter.
+     *
+     * Uses comma-separated IDs (OR within the facet), matching the local
+     * meta_query IN semantics. Used to re-enforce the filter on external-feed
+     * events whose remote may not honor the forwarded param.
+     *
+     * @param string $eventServiceBody The event's service body ID.
+     * @param string $filter           Comma-separated service body IDs.
+     * @return bool True when the event should be kept.
+     */
+    private static function event_matches_service_body_filter($eventServiceBody, $filter) {
+        $filter = trim((string) $filter);
+        if ($filter === '') {
+            return true;
+        }
+
+        $allowed = array_filter(array_map('trim', explode(',', $filter)), function ($id) {
+            return $id !== '';
+        });
+
+        if (empty($allowed)) {
+            return true;
+        }
+
+        $id = trim((string) $eventServiceBody);
+        return in_array($id, $allowed, true);
+    }
+
+    /**
      * Query events with given parameters
      *
      * @param string $status Post status
@@ -1634,6 +1663,27 @@ class EventsController {
                 }));
             }
 
+            // Enforce the service_body filter locally for the same reason as the
+            // category and event_type filters above.
+            $effective_service_body = self::effective_source_filter($source, 'service_body');
+            if ($effective_service_body !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_service_body) {
+                    $sb = isset($event['meta']['service_body']) ? $event['meta']['service_body'] : '';
+                    return self::event_matches_service_body_filter($sb, $effective_service_body);
+                }));
+            }
+
+            // Enforce the tags filter locally for the same reason as categories.
+            $effective_tags = self::effective_source_filter($source, 'tags');
+            if ($effective_tags !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_tags) {
+                    return TaxonomyQuery::event_matches_tag_filter(
+                        $event['tags'] ?? [],
+                        $effective_tags
+                    );
+                }));
+            }
+
             // Tag events with source info
             foreach ($events as &$event) {
                 $event['source_id'] = $sid;
@@ -1803,6 +1853,26 @@ class EventsController {
                 $events = array_values(array_filter($events, function ($event) use ($effective_event_type) {
                     $type = isset($event['meta']['event_type']) ? $event['meta']['event_type'] : '';
                     return self::event_matches_event_type_filter($type, $effective_event_type);
+                }));
+            }
+
+            // Enforce the service_body filter locally (see fetch_all_external_events).
+            $effective_service_body = self::effective_source_filter($source, 'service_body');
+            if ($effective_service_body !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_service_body) {
+                    $sb = isset($event['meta']['service_body']) ? $event['meta']['service_body'] : '';
+                    return self::event_matches_service_body_filter($sb, $effective_service_body);
+                }));
+            }
+
+            // Enforce the tags filter locally (see fetch_all_external_events).
+            $effective_tags = self::effective_source_filter($source, 'tags');
+            if ($effective_tags !== '') {
+                $events = array_values(array_filter($events, function ($event) use ($effective_tags) {
+                    return TaxonomyQuery::event_matches_tag_filter(
+                        $event['tags'] ?? [],
+                        $effective_tags
+                    );
                 }));
             }
 

--- a/includes/Rest/Helpers/TaxonomyQuery.php
+++ b/includes/Rest/Helpers/TaxonomyQuery.php
@@ -81,6 +81,10 @@ class TaxonomyQuery {
                     'terms' => $include_cat_ids,
                     'operator' => $operator
                 ];
+            } else {
+                // Include requested but no slug resolved locally (e.g. external-only
+                // category in a merged facet list). Strict AND: match nothing.
+                $tax_query[] = self::impossible_tax_query('category');
             }
         }
 
@@ -106,7 +110,20 @@ class TaxonomyQuery {
 
         // Handle tag inclusion
         if (!empty($tag_filter['include'])) {
-            $args['tag'] = $tag_filter['include'];
+            $include_tag_slugs = array_map('trim', explode(',', $tag_filter['include']));
+            $resolved_tag_slugs = [];
+            foreach ($include_tag_slugs as $slug) {
+                $term = get_term_by('slug', $slug, 'post_tag');
+                if ($term) {
+                    $resolved_tag_slugs[] = $slug;
+                }
+            }
+            if (!empty($resolved_tag_slugs)) {
+                $args['tag'] = implode(',', $resolved_tag_slugs);
+            } else {
+                // Include requested but no slug resolved locally — strict AND.
+                $tax_query[] = self::impossible_tax_query('post_tag');
+            }
         }
 
         // Handle tag exclusion via tax_query
@@ -136,6 +153,26 @@ class TaxonomyQuery {
         }
 
         return $args;
+    }
+
+    /**
+     * Build a tax_query clause that matches no posts.
+     *
+     * Used when an include filter was requested but none of its slugs resolve
+     * in the local taxonomy (e.g. a category/tag that exists only on an
+     * external feed). Strict AND across facets requires the local query to
+     * return nothing rather than silently dropping the constraint.
+     *
+     * @param string $taxonomy Taxonomy name (e.g. 'category', 'post_tag')
+     * @return array WordPress tax_query clause
+     */
+    private static function impossible_tax_query($taxonomy) {
+        return [
+            'taxonomy' => $taxonomy,
+            'field' => 'term_id',
+            'terms' => [0],
+            'operator' => 'IN',
+        ];
     }
 
     /**
@@ -216,6 +253,22 @@ class TaxonomyQuery {
         }
 
         return true;
+    }
+
+    /**
+     * Check whether an event's tag payload satisfies a filter string.
+     *
+     * Mirrors event_matches_category_filter for post_tag terms on external
+     * events. Used as a local backstop when the remote may ignore the
+     * forwarded `tags` param.
+     *
+     * @param array  $event_tags Event tag objects (each may have 'slug'/'name')
+     * @param string $filter     Comma-separated tag slugs/names (prefix with '-' to exclude)
+     * @param string $relation   'AND' or 'OR' - how to match multiple includes (default OR)
+     * @return bool True if the event passes the filter (empty filter passes everything)
+     */
+    public static function event_matches_tag_filter($event_tags, $filter, $relation = 'OR') {
+        return self::event_matches_category_filter($event_tags, $filter, $relation);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,8 @@ This project is licensed under the GPL v2 or later.
 * Fixed external feed sources ignoring the Event Type filter: filtering on Service (or Activity) now actually hides the other types coming from external feeds, even when the remote runs an older version or isn't a Mayo site. [#251]
 
 = 1.9.3 =
+* Fixed display filters not combining correctly across local and external event feeds: selecting a category or tag that exists only on an external source now hides all local events instead of showing every local match for the other facets. [#323]
+* Fixed external feed events not being re-filtered locally for Service Body and Tag selections, which could let non-matching events leak through from older or non-Mayo remote sites. [#323]
 * Added a "Relative to a monthly day" monthly recurrence option so committee meetings can be scheduled relative to a monthly anchor (e.g. the Monday before the 3rd Tuesday, or the Thursday after it). Available in the block-editor Event sidebar. [#312]
 
 = 1.9.2 =

--- a/tests/Unit/Rest/EventsControllerTest.php
+++ b/tests/Unit/Rest/EventsControllerTest.php
@@ -2267,4 +2267,31 @@ class EventsControllerTest extends TestCase {
         $this->assertFalse($this->eventMatchesEventType('Activity', 'Service,-Celebration'));
         $this->assertFalse($this->eventMatchesEventType('Celebration', 'Service,-Celebration'));
     }
+
+    /**
+     * Invoke the private static event_matches_service_body_filter for testing.
+     */
+    private function eventMatchesServiceBody(string $eventServiceBody, string $filter): bool {
+        $method = new \ReflectionMethod(EventsController::class, 'event_matches_service_body_filter');
+        $method->setAccessible(true);
+        return $method->invoke(null, $eventServiceBody, $filter);
+    }
+
+    /**
+     * An empty service_body filter constrains nothing.
+     */
+    public function testServiceBodyFilterEmptyKeepsEverything(): void {
+        $this->assertTrue($this->eventMatchesServiceBody('5', ''));
+        $this->assertTrue($this->eventMatchesServiceBody('', ''));
+    }
+
+    /**
+     * Service body include keeps only matching IDs (OR within the facet).
+     */
+    public function testServiceBodyFilterIncludeHidesNonMatches(): void {
+        $this->assertTrue($this->eventMatchesServiceBody('5', '5'));
+        $this->assertTrue($this->eventMatchesServiceBody('10', '5,10'));
+        $this->assertFalse($this->eventMatchesServiceBody('20', '5,10'));
+        $this->assertFalse($this->eventMatchesServiceBody('', '5'));
+    }
 }

--- a/tests/Unit/Rest/Helpers/TaxonomyQueryTest.php
+++ b/tests/Unit/Rest/Helpers/TaxonomyQueryTest.php
@@ -180,6 +180,13 @@ class TaxonomyQueryTest extends TestCase {
      * Test build_taxonomy_args with tags
      */
     public function testBuildTaxonomyArgsWithTags(): void {
+        Functions\when('get_term_by')->alias(function($field, $slug, $taxonomy) {
+            if ($taxonomy === 'post_tag' && $slug === 'featured') {
+                return (object)['term_id' => 42, 'slug' => 'featured'];
+            }
+            return null;
+        });
+
         $result = TaxonomyQuery::build_taxonomy_args('', 'OR', 'featured');
 
         $this->assertArrayHasKey('tag', $result);
@@ -213,6 +220,23 @@ class TaxonomyQueryTest extends TestCase {
     }
 
     /**
+     * Test build_taxonomy_args with unresolved include slugs matches nothing
+     */
+    public function testBuildTaxonomyArgsUnresolvedIncludeMatchesNothing(): void {
+        Functions\when('get_term_by')->justReturn(null);
+
+        $categoryResult = TaxonomyQuery::build_taxonomy_args('external-only', 'OR', '');
+        $this->assertArrayHasKey('tax_query', $categoryResult);
+        $this->assertEquals('category', $categoryResult['tax_query'][0]['taxonomy']);
+        $this->assertEquals([0], $categoryResult['tax_query'][0]['terms']);
+
+        $tagResult = TaxonomyQuery::build_taxonomy_args('', 'OR', 'external-only');
+        $this->assertArrayHasKey('tax_query', $tagResult);
+        $this->assertEquals('post_tag', $tagResult['tax_query'][0]['taxonomy']);
+        $this->assertEquals([0], $tagResult['tax_query'][0]['terms']);
+    }
+
+    /**
      * Test build_taxonomy_args handles non-existent terms
      */
     public function testBuildTaxonomyArgsHandlesNonExistentTerms(): void {
@@ -220,8 +244,8 @@ class TaxonomyQueryTest extends TestCase {
 
         $result = TaxonomyQuery::build_taxonomy_args('nonexistent', 'OR', '');
 
-        // Should not add tax_query if term doesn't exist
-        $this->assertArrayNotHasKey('tax_query', $result);
+        $this->assertArrayHasKey('tax_query', $result);
+        $this->assertEquals([0], $result['tax_query'][0]['terms']);
     }
 
     /**
@@ -364,5 +388,17 @@ class TaxonomyQueryTest extends TestCase {
         // AND: must carry both.
         $this->assertFalse(TaxonomyQuery::event_matches_category_filter($oneOfTwo, 'conventions,workshops', 'AND'));
         $this->assertTrue(TaxonomyQuery::event_matches_category_filter($bothCats, 'conventions,workshops', 'AND'));
+    }
+
+    /**
+     * Tag filter enforcement mirrors category semantics on event payloads.
+     */
+    public function testEventMatchesTagFilterNarrowsBySlug(): void {
+        $matching = [$this->cat('nj-region', 'NJ Region')];
+        $other    = [$this->cat('featured', 'Featured')];
+
+        $this->assertTrue(TaxonomyQuery::event_matches_tag_filter($matching, 'nj-region'));
+        $this->assertFalse(TaxonomyQuery::event_matches_tag_filter($other, 'nj-region'));
+        $this->assertFalse(TaxonomyQuery::event_matches_tag_filter([], 'nj-region'));
     }
 }


### PR DESCRIPTION
## Summary
- Local category/tag queries now match nothing when an include filter slug does not resolve in the local taxonomy (e.g. external-only categories like Convention or NJ Region), so AND semantics hold across facets when mixing local and external feeds.
- External feed events are now re-filtered locally for Service Body and Tag selections, mirroring the existing event_type and categories enforcement.

## Test plan
- [x] Unit tests for unresolved local category/tag slugs (`TaxonomyQueryTest`)
- [x] Unit tests for service body and tag external enforcement helpers
- [ ] Manual: select Service + external-only category — local Service events should be hidden
- [ ] Manual: select Service Body filter — external events from non-Mayo remotes should respect the filter

Closes #323

Made with [Cursor](https://cursor.com)