### PR TITLE
Bump version to 1.9.4

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.9.3
+ * Version: 1.9.4
  * Requires at least: 6.7
  * Tested up to: 7.0
  * Author: bmlt-enabled
@@ -24,7 +24,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.9.3');
+define('MAYO_VERSION', '1.9.4');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mayo",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mayo",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-react": "^7.26.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 1.9.3
+Stable tag: 1.9.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- Bump version strings to 1.9.4 in `mayo-events-manager.php`, `readme.txt`, `package.json`, and `package-lock.json`
- Changelog for 1.9.4 is already in `readme.txt`

## Test plan
- [ ] CI passes
- [ ] Tag `1.9.4` after merge to trigger release workflow

Made with [Cursor](https://cursor.com)