### PR TITLE
Fix time select overflow and text clipping in narrow containers

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -2,6 +2,9 @@
     max-width: 600px;
     margin: 2em auto;
     padding: 1em;
+    /* Without this the 1em padding is added *outside* max-width, so the form
+       overflows any container narrower than 600px by 2em (#328). */
+    box-sizing: border-box;
 }
 
 .mayo-form-field {
@@ -17,7 +20,9 @@
 .mayo-form-field input,
 .mayo-form-field textarea {
     width: 100%;
+    max-width: 100%;
     padding: 0.5em;
+    box-sizing: border-box;
 }
 
 .mayo-submit-button {
@@ -954,11 +959,18 @@
 
 .mayo-form-field select {
     width: 100%;
-    padding: 0.5em;
+    max-width: 100%;
+    padding: 0.35em 0.5em;
     border: 1px solid #ddd;
     border-radius: 4px;
     background-color: white;
-    height: 40px; /* Match input height */
+    /* `min-height` rather than a fixed `height` so a theme with a larger base
+       font grows the control instead of clipping the text baseline (#328).
+       40px keeps the default rendering matched to the text inputs. */
+    min-height: 40px;
+    height: auto;
+    line-height: 1.5;
+    box-sizing: border-box;
     cursor: pointer;
 }
 
@@ -972,39 +984,54 @@
     border-color: #999;
 }
 
+/* The date/time rows wrap on the *container's* width rather than waiting for
+   the 600px viewport media query below, so the form stays inside a narrow
+   content column (e.g. a page with a sidebar) on any viewport (#328). */
 .mayo-datetime-group {
     display: flex;
+    flex-wrap: wrap;
     gap: 20px;
     margin-bottom: 1em;
 }
 
 .mayo-datetime-group .mayo-form-field {
-    flex: 1;
+    /* Stack the Start and End columns once neither can hold a legible row. */
+    flex: 1 1 260px;
+    min-width: 0;
 }
 
 .mayo-datetime-inputs {
     display: flex;
+    flex-wrap: wrap;
     gap: 10px;
 }
 
 .mayo-datetime-inputs input {
-    flex: 1;
+    /* Wrap the time selects onto their own line before the date control is
+       squeezed below its intrinsic width and starts overflowing. */
+    flex: 1 1 140px;
+    min-width: 0;
 }
 
 /* Time entry selects (Hour / Minute / AM-PM) rendered by TimeField. */
 .mayo-datetime-inputs .mayo-time-inputs {
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .mayo-time-inputs {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 6px;
 }
 
 .mayo-time-inputs select {
-    flex: 1;
-    min-width: 0;
+    flex: 1 1 auto;
+    /* Floor the selects at a width that still fits the "Hour"/"Min" labels and
+       the native dropdown arrow; below this they truncate (#328). In `em` so
+       the floor tracks the theme's font size. */
+    min-width: 5em;
     /* Override the global `.mayo-form-field select { width: 100% }` so the
        AM/PM select (flex: 0 0 auto) doesn't take a 100% flex-basis and
        overflow the column, overlapping the adjacent Start/End field (#310). */
@@ -1020,6 +1047,13 @@
     .mayo-datetime-group {
         flex-direction: column;
         gap: 10px;
+    }
+
+    /* In a column flex container `flex-basis` sizes the *height*, so the
+       260px basis used for container-width wrapping must be reset here or
+       each field would be forced 260px tall (#328). */
+    .mayo-datetime-group .mayo-form-field {
+        flex-basis: auto;
     }
 
     .mayo-event-header {
@@ -2981,11 +3015,13 @@
 
 .mayo-datetime-row {
     display: flex;
+    flex-wrap: wrap;
     gap: 20px;
 }
 
 .mayo-datetime-row .mayo-form-field {
-    flex: 1;
+    flex: 1 1 220px;
+    min-width: 0;
     margin-bottom: 0.5em;
 }
 
@@ -3009,6 +3045,12 @@
     .mayo-datetime-row {
         flex-direction: column;
         gap: 0;
+    }
+
+    /* Same reason as `.mayo-datetime-group` above: reset the row's wrapping
+       basis so it doesn't become a forced height in column direction. */
+    .mayo-datetime-row .mayo-form-field {
+        flex-basis: auto;
     }
 
     .mayo-display-window-fieldset {

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,9 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.9.5 =
+* Fixed the event and announcement submission forms overflowing their container and clipping the Hour/Minute/AM-PM time dropdowns when the form is placed in a narrow column, such as a page with a fixed or sticky sidebar. The date and time controls now wrap to fit the space available and the dropdowns keep a legible minimum width, so the "Hour" and "Min" labels and selected values are no longer cut off. [#328]
+
 = 1.9.4 =
 * Fixed event submission form showing empty Categories or Tags section headers when `categories="none"` or `tags="none"` is used in `[mayo_event_form]`. [#325]
 * Documented that category and tag names with spaces should use dashes in shortcode parameters (e.g., a category named "Cell Awareness" is specified as `cell-awareness` in `[mayo_announcement_form]`). [#321]


### PR DESCRIPTION
Closes #328

`[mayo_event_form]` rendered inside a constrained content column (a page with a fixed/sticky sidebar) overflowed its container and clipped the Hour/Minute/AM-PM dropdowns. Three separate causes, all in `assets/css/public.css`:

**1. Wrapping was tied to the viewport, not the container.** The date/time rows only stacked at a `max-width: 600px` *viewport* media query, so a narrow *container* on a wide viewport kept the Start and End columns side by side and crushed them. They now wrap on container width (`flex-wrap` + a `flex-basis`).

Because the existing media queries switch those containers to `flex-direction: column` — where `flex-basis` sizes the **height** — the basis is reset to `auto` inside them; otherwise each field would have been forced 260px tall on mobile.

**2. The time selects had no legible floor.** `min-width: 0` let them shrink to nothing, truncating the "Hour"/"Min" labels and the selected values. They now floor at `5em` — in `em` so the floor tracks the theme font size rather than a hard 80px.

**3. `box-sizing` was never declared** on the form, its inputs, or its selects:
- Under the `border-box` reset most themes apply, the select's fixed `height: 40px` minus `0.5em` padding left a content box shorter than the line box — this is the reported baseline clipping.
- Under `content-box`, padding was added *outside* the declared `100%`/`600px` widths, pushing the form past its container.

`box-sizing` is now explicit, and the select uses `min-height` instead of a fixed `height` so a theme with a larger base font grows the control rather than clipping it.

## Result

At the default 600px form width the date input and the time selects now wrap onto separate lines within each column, so all three dropdowns render at a legible width instead of ~40px each — the current side-by-side layout is already cramped enough to truncate them.

Default rendering is otherwise unchanged: at a 16px base font the select still resolves to exactly 40px, matching the text inputs as before.

## Notes

- CSS-only. `public.css` is enqueued directly (not bundled by webpack), so no `npm run build` is needed.
- No PHP or JS changed, so the PHPUnit suite is unaffected. The pre-existing `composer lint` failures are in `mayo-events-manager.php`, which this branch does not touch.
- I was not able to verify visually — headless Chrome would not run in this environment — so the layout behavior above is reasoned from the flexbox rules rather than measured in a browser. Worth a quick look in a sidebar layout before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)