### PR TITLE
Bump version to 1.9.5

### DIFF
--- a/mayo-events-manager.php
+++ b/mayo-events-manager.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Mayo Events Manager
  * Description: A plugin for managing and displaying events.
- * Version: 1.9.4
+ * Version: 1.9.5
  * Requires at least: 6.7
  * Tested up to: 7.0
  * Author: bmlt-enabled
@@ -24,7 +24,7 @@ if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly
 }
 
-define('MAYO_VERSION', '1.9.4');
+define('MAYO_VERSION', '1.9.5');
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/Admin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayo",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, bmlt, narcotics anonymous, na
 Requires PHP: 8.2
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 1.9.4
+Stable tag: 1.9.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Release prep for 1.9.5.

Bumps the version in all four locations:

- `mayo-events-manager.php` — plugin header `Version:` and the `MAYO_VERSION` constant
- `readme.txt` — `Stable tag:`
- `package.json` — `version`

The `= 1.9.5 =` changelog section already landed with #329 and is the top section, so the release workflow will pick it up as the release notes body.

### Contents of 1.9.5

- #328 — time select fields overflowing their container and clipping text in bounded layouts (fix in #329, confirmed working by the reporter on build 229)

Once merged, tagging `1.9.5` triggers the release workflow: GitHub Release + WordPress.org deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)