### PR TITLE
Stack submission form Start/End date fields to prevent theme occlusion [#331]

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -984,20 +984,18 @@
     border-color: #999;
 }
 
-/* The date/time rows wrap on the *container's* width rather than waiting for
-   the 600px viewport media query below, so the form stays inside a narrow
-   content column (e.g. a page with a sidebar) on any viewport (#328). */
+/* Stack the Start and End date/time fields in a single full-width column so
+   both stay visible and reachable on every theme. A side-by-side flex row
+   (even one that wrapped on narrow containers, #328) could still push the End
+   field off-page or behind a theme's fixed/floating sidebar widget on wider
+   layouts, with no way to scroll to it — leaving required fields silently
+   hidden (#331). Stacking makes each field span the full width, so its label
+   and required asterisk are always on the left edge and never occluded. The
+   inner date + time controls still wrap on the field's width
+   (see .mayo-datetime-inputs below). */
 .mayo-datetime-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
+    display: block;
     margin-bottom: 1em;
-}
-
-.mayo-datetime-group .mayo-form-field {
-    /* Stack the Start and End columns once neither can hold a legible row. */
-    flex: 1 1 260px;
-    min-width: 0;
 }
 
 .mayo-datetime-inputs {
@@ -1044,18 +1042,6 @@
 }
 
 @media (max-width: 600px) {
-    .mayo-datetime-group {
-        flex-direction: column;
-        gap: 10px;
-    }
-
-    /* In a column flex container `flex-basis` sizes the *height*, so the
-       260px basis used for container-width wrapping must be reset here or
-       each field would be forced 260px tall (#328). */
-    .mayo-datetime-group .mayo-form-field {
-        flex-basis: auto;
-    }
-
     .mayo-event-header {
         gap: 12px;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,9 @@ This project is licensed under the GPL v2 or later.
 
 == Changelog ==
 
+= 1.9.6 =
+* Fixed the Start and End date/time fields on the event and announcement submission forms sitting side by side, where the End field could be pushed off-page or hidden behind a theme's fixed or floating sidebar widget with no way to scroll to it — leaving required fields invisible. The two fields now stack in a single full-width column so both, and their required asterisks, stay visible on every theme. [#331]
+
 = 1.9.5 =
 * Fixed the event and announcement submission forms overflowing their container and clipping the Hour/Minute/AM-PM time dropdowns when the form is placed in a narrow column, such as a page with a fixed or sticky sidebar. The date and time controls now wrap to fit the space available and the dropdowns keep a legible minimum width, so the "Hour" and "Min" labels and selected values are no longer cut off. [#328]
 


### PR DESCRIPTION
Closes #331

## Problem
On the event and announcement submission forms, `.mayo-datetime-group` laid the **Start** and **End** date/time fields out as a side-by-side flex row. The container-width wrapping added in #328 (1.9.5) helped narrow columns, but on wider layouts the two fields still sit side by side — and on the reporter's theme the End field was pushed off-page / hidden behind a fixed sidebar widget with **no way to scroll to it**. Testers couldn't see that required fields were blank because only "Start Date" was visible.

The reporter's own workaround was to force the group to stop being a side-by-side row (`display: inline`).

## Fix
Make `.mayo-datetime-group` a plain full-width **block** so Start and End always stack in a single visible column, exactly like every other field on the form. Each field's label and required asterisk stay on the left edge and can't be occluded by a right-side theme widget. The inner date + time controls (`.mayo-datetime-inputs`) keep wrapping on the field's own width, so the #328/#310 clipping fixes are unaffected.

- `.mayo-datetime-group`: `display: flex; flex-wrap: wrap` → `display: block`; dropped the `flex: 1 1 260px` child rule.
- Removed the now-redundant `.mayo-datetime-group` overrides from the `@media (max-width: 600px)` block (it was only resetting flex properties that no longer exist).
- Scoped strictly to `.mayo-datetime-group`; the admin display-window fieldset variant and other form groups are untouched.

## Notes
- CSS-only change to a directly-enqueued static asset (`assets/css/public.css`) — no build step involved.
- Changelog updated in `readme.txt` under a new `= 1.9.6 =` section. Version constants are intentionally **not** bumped on a feature branch.

## Verification
- CSS braces balanced.
- Cannot visually verify in this environment (no headless browser available). Reasoning: with a single full-width column each field spans the content width, so no field is positioned in the right-hand region a sidebar widget overlaps; narrow containers were already covered by the inner `.mayo-datetime-inputs` wrapping.